### PR TITLE
Fixed issue in get_result() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ PyWren-IBM-Cloud shipped with default runtime
 
 | Runtime name | Python version | Packages included |
 | ----| ----| ---- |
-| python-jessie:3 | 3.6 | [list of packages](https://console.bluemix.net/docs/openwhisk/openwhisk_reference.html#openwhisk_ref_python_environments_jessie) |
+| python:3.6 | 3.6 | [list of packages](https://console.bluemix.net/docs/openwhisk/openwhisk_reference.html#openwhisk_ref_python_environments_3.6) |
 
 To deploy the default runtime, navigate into `pywren` folder and execute:
 
 	./deploy_pywren.sh
 
-This script will automatically create a Python 3.6 action named `pywren_3.6` which is based on `python-jessie:3` IBM docker image. 
+This script will automatically create a Python 3.6 action named `pywren_3.6` which is based on `python:3.6` IBM docker image (Debian Jessie). 
 This action is the main runtime used to run functions within IBM Cloud Functions with PyWren. 
 Notice also that script make uses of `bx wsk` command line tool, so previously to run the deploy script, login to your desired region where you want to run PyWren `bx login`, and target to the Cloud Foundry org/space by running `bx target --cf`.
 
@@ -100,7 +100,7 @@ ibm_cos:
     # make sure to use full path.
     # for example https://s3-api.us-geo.objectstorage.softlayer.net
     endpoint   : <COS_API_ENDPOINT>
-	 # this is preferable authentication method for IBM COS
+    # this is preferable authentication method for IBM COS
     api_key    : <COS_API_KEY>
     # alternatively you may use HMAC authentication method
     # access_key : <ACCESS_KEY>

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -267,18 +267,24 @@ class ibm_cf_executor(object):
         if self.cf_cluster:
             verbose = True
 
-        if not futures:
-            futures = self.futures
+        if futures:
+            # Ensure futures is always a list
+            if type(futures) != list:
+                ftrs = [futures]
+            else:
+                ftrs = futures
+        else:
+            ftrs = self.futures
 
         if not futures:
             raise Exception('You must run pw.call_async(), pw.map()'
                             ' or pw.map_reduce() before call pw.get_result()')
 
-        if (type(futures) == list and len(futures) == 1) or type(futures) == future:
-            result = self._get_result(futures[0], throw_except=throw_except,
+        if len(ftrs) == 1:
+            result = self._get_result(ftrs[0], throw_except=throw_except,
                                       verbose=verbose, timeout=timeout)
         else:
-            result = self._get_all_results(futures, throw_except=throw_except,
+            result = self._get_all_results(ftrs, throw_except=throw_except,
                                            verbose=verbose, timeout=timeout)
 
         msg = "Executor ID {} Finished\n".format(self.executor_id)

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -108,10 +108,9 @@ class ibm_cf_executor(object):
             raise Exception('You cannot run pw.call_async() in the current state,'
                             ' create a new pywren.ibm_cf_executor() instance.')
 
-        future = self.executor.call_async(func, data, extra_env, extra_meta)[0]
-        self.futures.append(future)
+        self.futures = self.executor.call_async(func, data, extra_env, extra_meta)
 
-        return future
+        return self.futures[0]
 
     def map(self, func, iterdata, extra_env=None, extra_meta=None,
             remote_invocation=False, invoke_pool_threads=10, data_all_as_one=True,
@@ -179,6 +178,9 @@ class ibm_cf_executor(object):
             for futures_list in new_futures:
                 self.futures.extend(futures_list)
 
+        if len(self.futures) == 1:
+            return self.futures[0]
+
         return self.futures
 
     def map_reduce(self, map_function, map_iterdata, reduce_function,
@@ -212,7 +214,7 @@ class ibm_cf_executor(object):
                                                 reducer_wait_local,
                                                 throw_except, extra_env, extra_meta)
 
-        if type(self.futures) == list and len(self.futures) == 1:
+        if len(self.futures) == 1:
             return self.futures[0]
 
         return self.futures
@@ -268,12 +270,13 @@ class ibm_cf_executor(object):
             verbose = True
 
         if futures:
-            # Ensure futures is always a list
+            # Ensure futures is a list
             if type(futures) != list:
                 ftrs = [futures]
             else:
                 ftrs = futures
         else:
+            # In this case self.futures is always a list
             ftrs = self.futures
 
         if not futures:


### PR DESCRIPTION
Commits f38422d 4c17730:
- Fixed an issue in get_result() method when futures is not a list. Now it ensures that futures is always a list before call the corresponding internal _get_result()/_get_all_results() method.

Commit bc1d3a1:
- Modified default runtime name in readme and link to the list of included packages in order to match the official IBM documentation.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

