### PR TITLE
bucket streams split wrong fix

### DIFF
--- a/pywren/pywren_ibm_cloud/wrenutil.py
+++ b/pywren/pywren_ibm_cloud/wrenutil.py
@@ -52,8 +52,10 @@ def iterdata_as_list(iterdata):
     """
     Converts iteradat to a list
     """
-    if type(iterdata) != list:
+    if type(iterdata) == str:
         return [iterdata]
+    elif type(iterdata) != list:
+        return list(iterdata)
     else:
         return iterdata 
 

--- a/pywren/pywren_ibm_cloud/wrenutil.py
+++ b/pywren/pywren_ibm_cloud/wrenutil.py
@@ -53,7 +53,7 @@ def iterdata_as_list(iterdata):
     Converts iteradat to a list
     """
     if type(iterdata) != list:
-        return list(iterdata)
+        return [iterdata]
     else:
         return iterdata 
 


### PR DESCRIPTION
minor fix
when using list() method on a string, python splits it by chars instead of making an one element list object