### PR TITLE
Add support to generate execution timeline plots

### DIFF
--- a/pywren/pywren_ibm_cloud/partitioner.py
+++ b/pywren/pywren_ibm_cloud/partitioner.py
@@ -93,7 +93,8 @@ def split_object_from_key(map_func_args_list, chunk_size, storage):
     """
     Create partitions from a list of COS objects keys
     """
-    logger.info('Creating dataset chunks from object keys ...')
+    if chunk_size:
+        logger.info('Creating chunks from object keys...')
     partitions = list()
 
     for entry in map_func_args_list:
@@ -125,7 +126,8 @@ def split_object_from_url(map_func_args_list, chunk_size):
     """
     Create partitions from a list of objects urls
     """
-    logger.info('Creating dataset chunks from urls ...')
+    if chunk_size:
+        logger.info('Creating chunks from urls...')
     partitions = list()
 
     for entry in map_func_args_list:

--- a/pywren/pywren_ibm_cloud/plots.py
+++ b/pywren/pywren_ibm_cloud/plots.py
@@ -1,0 +1,126 @@
+import matplotlib
+matplotlib.use('Agg')
+import os
+import pylab
+import logging
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from matplotlib import patches as mpatches
+from matplotlib.collections import LineCollection
+sns.set_style('whitegrid')
+logger = logging.getLogger(__name__)
+
+
+def create_timeline(dst, name, run_statuses, invoke_statuses):
+    results_df = pd.DataFrame(run_statuses)
+    invoke_df = pd.DataFrame(invoke_statuses)
+
+    results_df = pd.concat([results_df, invoke_df], axis=1)
+    Cols = list(results_df.columns)
+    for i, item in enumerate(results_df.columns):
+        if item in results_df.columns[:i]:
+            Cols[i] = "toDROP"
+    results_df.columns = Cols
+    results_df = results_df.drop("toDROP", 1)
+
+    palette = sns.color_palette("deep", 6)
+    time_offset = np.min(results_df.host_submit_time)
+    fig = pylab.figure(figsize=(10, 6))
+    ax = fig.add_subplot(1, 1, 1)
+    total_jobs = len(results_df)
+
+    y = np.arange(total_jobs)
+    point_size = 10
+
+    fields = [
+              ('host submit', results_df.host_submit_time - time_offset),
+              ('action start', results_df.start_time - time_offset),
+              ('jobrunner start', results_df.jobrunner_start - time_offset),
+              ('action done', results_df.end_time - time_offset),
+              ('results fetched', results_df.download_output_timestamp - time_offset)
+             ]
+
+    patches = []
+    for f_i, (field_name, val) in enumerate(fields):
+        ax.scatter(val, y, c=[palette[f_i]], edgecolor='none', s=point_size, alpha=0.8)
+        patches.append(mpatches.Patch(color=palette[f_i], label=field_name))
+
+    ax.set_xlabel('wallclock time (sec)')
+    ax.set_ylabel('job')
+    #pylab.ylim(0, 10)
+
+    legend = pylab.legend(handles=patches, loc='upper right', frameon=True)
+    #pylab.title("Runtime for {} jobs of {:3.0f}M double ops (dgemm) each".format(total_jobs, JOB_GFLOPS))
+    legend.get_frame().set_facecolor('#FFFFFF')
+
+    plot_step = int(np.max([1, total_jobs/32]))
+
+    y_ticks = np.arange(total_jobs//plot_step + 2) * plot_step
+
+    ax.set_yticks(y_ticks)
+    ax.set_ylim(-0.02*total_jobs, total_jobs*1.05)
+
+    ax.set_xlim(-1, np.max(results_df.download_output_timestamp - time_offset)*1.35)
+    #ax.set_xlim(-0.02, np.max(8))
+
+    for y in y_ticks:
+        ax.axhline(y, c='k', alpha=0.1, linewidth=1)
+
+    ax.grid(False)
+    fig.tight_layout()
+    fig.savefig(os.path.join(dst, name+"_timeline.png"))
+
+
+def create_histogram(dst, name, run_statuses, x_lim=300):
+    runtime_bins = np.linspace(0, x_lim, x_lim)
+
+    def compute_times_rates(d):
+        x = np.array(d)
+
+        tzero = np.min(x[:, 0])
+        start_time = x[:, 0] - tzero
+        end_time = x[:, 1] - tzero
+
+        N = len(start_time)
+
+        runtime_jobs_hist = np.zeros((N, len(runtime_bins)))
+
+        for i in range(N):
+            s = start_time[i]
+            e = end_time[i]
+            a, b = np.searchsorted(runtime_bins, [s, e])
+            if b-a > 0:
+                runtime_jobs_hist[i, a:b] = 1
+
+        return {'start_time': start_time,
+                'end_time': end_time,
+                'runtime_jobs_hist': runtime_jobs_hist}
+
+    fig = pylab.figure(figsize=(10, 6))
+    ax = fig.add_subplot(1, 1, 1)
+
+    time_rates = [(rs['start_time'], rs['end_time']) for rs in run_statuses]
+
+    time_hist = compute_times_rates(time_rates)
+
+    N = len(time_hist['start_time'])
+    line_segments = LineCollection([[[time_hist['start_time'][i], i],
+                                     [time_hist['end_time'][i], i]] for i in range(N)],
+                                   linestyles='solid', color='k', alpha=0.4, linewidth=0.2)
+
+    ax.add_collection(line_segments)
+
+    ax.plot(runtime_bins, time_hist['runtime_jobs_hist'].sum(axis=0),
+            label='active jobs total', zorder=-1)
+
+    ax.set_xlim(0, x_lim)
+    ax.set_ylim(0, len(time_hist['start_time'])*1.05)
+    ax.set_xlabel("time (sec)")
+
+    ax.set_ylabel("IBM Cloud function execution")
+    ax.grid(False)
+    ax.legend(loc='upper right')
+
+    fig.tight_layout()
+    fig.savefig(os.path.join(dst, name+"_histogram.png"))

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -147,7 +147,7 @@ class ibm_cf_executor:
             return futures[0]
         return futures
 
-    def map_reduce(self, map_function, map_iterdata, reduce_function, chunk_size=None, 
+    def map_reduce(self, map_function, map_iterdata, reduce_function, chunk_size=None,
                    extra_env=None, extra_meta=None, remote_invocation=False,
                    reducer_one_per_object=False, reducer_wait_local=True,
                    invoke_pool_threads=10, data_all_as_one=True,
@@ -269,16 +269,16 @@ class ibm_cf_executor:
 
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(timeout)
-        
-        if not self.cf_cluster or logger.getEffectiveLevel() == logging.WARNING:
+
+        if self.cf_cluster or logger.getEffectiveLevel() != logging.WARNING:
+            pbar = None
+        else:
             import tqdm
             print()
             pbar = tqdm.tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ',
                              total=len(ftrs), disable=False)
-        else:
-            pbar = None
 
-        try:                
+        try:
             wait(ftrs, self.executor_id, self.internal_storage, throw_except=throw_except,
                  THREADPOOL_SIZE=THREADPOOL_SIZE, WAIT_DUR_SEC=WAIT_DUR_SEC, pbar=pbar)
             result = [f.result() for f in ftrs if f.done and not f.futures]

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -326,6 +326,27 @@ class ibm_cf_executor:
             return result[0]
         return result
 
+    def create_timeline_plots(self, dst, name, run_statuses=None, invoke_statuses=None):
+        """
+        Creates timeline and histogram of the current execution in dst.
+
+        :param dst: destination folder to save .png plots.
+        :param name: name of the file.
+        :param run_statuses: run statuses timestamps.
+        :param invoke_statuses: invocation statuses timestamps.
+        """
+        from pywren_ibm_cloud.plots import create_timeline, create_histogram
+
+        if self.futures and not run_statuses and not invoke_statuses:
+            run_statuses = [f.run_status for f in self.futures]
+            invoke_statuses = [f.invoke_status for f in self.futures]
+
+        if not run_statuses and not invoke_statuses:
+            raise Exception('You must provide run_statuses and invoke_statuses')
+
+        create_timeline(dst, name, run_statuses, invoke_statuses)
+        create_histogram(dst, name, run_statuses, x_lim=150)
+
     def clean(self, local_execution=True):
         """
         Deletes all the files from COS. These files include the function,

--- a/pywren/pywren_ibm_cloud/wrenutil.py
+++ b/pywren/pywren_ibm_cloud/wrenutil.py
@@ -79,7 +79,7 @@ def sizeof_fmt(num, suffix='B'):
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
-class WrappedStreamingBody(object):
+class WrappedStreamingBody:
     """
     Wrap boto3's StreamingBody object to provide enough Python fileobj functionality
     so that tar/gz can happen in memory


### PR DESCRIPTION
Created built-in method that generates execution timeline plots in a specified folder.

How to use?
Map:
```
pw = pywren.ibm_cf_executor()
futures = pw.map(my_map_function, range(200))
result pw.get_result()
pw.create_timeline_plots(dst='/home/jsampe/desktop', name='testmap')
```

Map-Reduce: (need to return statuses from reduce, for now)
```
pw = pywren.ibm_cf_executor()
futures = pw.map(my_map_function, range(200), my_reduce_function)
result = pw.get_result()
pw.create_timeline_plots(dst='/home/jsampe/desktop', name='testmapreduce',
                         result['run_statuses'], result['invoke_statuses'] )
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

