### PR TITLE
Updated deploy_runtime script, clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ As the current **IBM Watson Studio** runtimes does not contains the **PyWren** p
 try:
     import pywren_ibm_cloud as pywren
 except:
-    !curl -fsSL "https://raw.githubusercontent.com/pywren/pywren-ibm-cloud/master/install_pywren.sh" | sh
+    !curl -fsSL "https://git.io/fhe9X" | sh
     import pywren_ibm_cloud as pywren
 ```
 

--- a/pywren/pywren_ibm_cloud/cf_connector.py
+++ b/pywren/pywren_ibm_cloud/cf_connector.py
@@ -86,8 +86,8 @@ class CloudFunctions:
         cfexec['code'] = base64.b64encode(code).decode("utf-8") if is_binary else code
         data['exec'] = cfexec
 
-        res = self.session.put(url, json=data, headers=self.headers)
-        data = res.json()
+        res = self.session.put(url, json=data)
+
         if res.status_code != 200:
             print('An error occurred updating action {}'.format(action_name))
         else:
@@ -97,11 +97,25 @@ class CloudFunctions:
         """
         Get an IBM Cloud Function
         """
-        print ("I am about to get a cloud function action")
+        print ("I am about to get a cloud function action: {}".format(action_name))
         url = os.path.join(self.endpoint, 'api', 'v1', 'namespaces',
                            self.namespace, 'actions', action_name)
-        res = self.session.get(url, headers=self.headers)
+        res = self.session.get(url)
         return res.json()
+
+    def delete_action(self, action_name):
+        """
+        Delete an IBM Cloud Function
+        """
+        print ("I am about to delete a cloud function action: {}".format(action_name))
+        url = os.path.join(self.endpoint, 'api', 'v1', 'namespaces',
+                           self.namespace, 'actions', action_name)
+        res = self.session.delete(url)
+
+        if res.status_code != 200:
+            print('An error occurred deleting action {}'.format(action_name))
+        else:
+            print("OK --> Deleted action {}".format(action_name))
 
     def invoke(self, action_name, payload):
         """
@@ -179,3 +193,15 @@ class CloudFunctions:
         except:
             conn.close()
             return self.internal_invoke(action_name, payload)
+
+    def invoke_with_result(self, action_name, payload={}):
+        """
+        Invoke an IBM Cloud Function waiting for the result.
+        """
+        url = os.path.join(self.endpoint, 'api', 'v1',
+                           'namespaces', self.namespace, 'actions',
+                           action_name+"?blocking=true&result=true")
+        resp = self.session.post(url, json=payload)
+        result = resp.json()
+
+        return result

--- a/pywren/pywren_ibm_cloud/storage/backends/cos.py
+++ b/pywren/pywren_ibm_cloud/storage/backends/cos.py
@@ -15,7 +15,6 @@
 #
 
 import logging
-import requests
 import ibm_boto3
 import ibm_botocore
 from datetime import datetime
@@ -23,6 +22,8 @@ from pywren_ibm_cloud.wrenutil import sizeof_fmt
 from ibm_botocore.credentials import DefaultTokenManager
 from pywren_ibm_cloud.storage.exceptions import StorageNoSuchKeyError
 
+logging.getLogger('ibm_boto3').setLevel(logging.CRITICAL)
+logging.getLogger('ibm_botocore').setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
 
 
@@ -32,19 +33,15 @@ class COSBackend:
     """
 
     def __init__(self, cos_config):
-        logging.getLogger('ibm_boto3').setLevel(logger.getEffectiveLevel())
-        logging.getLogger('ibm_botocore').setLevel(logger.getEffectiveLevel())
-        logger.debug("COSBacked init method")
-        service_endpoint = cos_config.get('endpoint').replace('http:', 'https:')           
+        service_endpoint = cos_config.get('endpoint').replace('http:', 'https:')
 
         if 'api_key' in cos_config:
-            logger.debug("api key found in configuration")
             client_config = ibm_botocore.client.Config(signature_version='oauth',
                                                        max_pool_connections=200,
                                                        user_agent_extra='pywren-ibm-cloud')
             api_key = cos_config.get('api_key')
             token_manager = DefaultTokenManager(api_key_id=api_key)
-            
+
             if 'token' in cos_config:
                 token_manager._token = cos_config['token']
                 expiry_time = cos_config['token_expiry_time']
@@ -57,17 +54,15 @@ class COSBackend:
             if 'token' not in cos_config:
                 cos_config['token'] = token_manager.get_token()
                 cos_config['token_expiry_time'] = token_manager._expiry_time.strftime('%Y-%m-%d %H:%M:%S.%f%z')
-        
+
         elif {'secret_key', 'access_key'} <= set(cos_config):
-            logger.debug("secret_key and access_key found in configuration")
-            
             secret_key = cos_config.get('secret_key')
             access_key = cos_config.get('access_key')
             client_config = ibm_botocore.client.Config(max_pool_connections=200,
                                                        user_agent_extra='pywren-ibm-cloud')
             self.cos_client = ibm_boto3.client('s3',
-                                               aws_access_key_id = access_key, 
-                                               aws_secret_access_key = secret_key,
+                                               aws_access_key_id=access_key,
+                                               aws_secret_access_key=secret_key,
                                                config=client_config,
                                                endpoint_url=service_endpoint)
 
@@ -86,7 +81,7 @@ class COSBackend:
         :type data: str/bytes
         :return: None
         """
-        try:   
+        try:
             res = self.cos_client.put_object(Bucket=bucket_name, Key=key, Body=data)
             status = 'OK' if res['ResponseMetadata']['HTTPStatusCode'] == 200 else 'Error'
             try:
@@ -118,7 +113,7 @@ class COSBackend:
                 raise StorageNoSuchKeyError(key)
             else:
                 raise e
-    
+
     def head_object(self, bucket_name, key):
         """
         Head object from COS with a key. Throws StorageNoSuchKeyError if the given key does not exist.
@@ -127,14 +122,14 @@ class COSBackend:
         :rtype: str/bytes
         """
         try:
-            metadata = self.cos_client.head_object(Bucket=bucket_name, Key=key)       
+            metadata = self.cos_client.head_object(Bucket=bucket_name, Key=key)
             return metadata['ResponseMetadata']['HTTPHeaders']
         except ibm_botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(key)
             else:
                 raise e
-    
+
     def delete_object(self, bucket_name, key):
         """
         Delete an object from storage.
@@ -142,7 +137,7 @@ class COSBackend:
         :param key: data key
         """
         return self.cos_client.delete_object(Bucket=bucket_name, Key=key)
-    
+
     def delete_objects(self, bucket_name, key_list):
         """
         Delete a list of objects from storage.
@@ -152,11 +147,11 @@ class COSBackend:
         result = []
         max_keys_num = 1000
         for i in range(0, len(key_list), max_keys_num):
-            delete_keys = {'Objects' : []}
-            delete_keys['Objects'] = [{'Key' : k} for k in key_list[i:i+max_keys_num]]
+            delete_keys = {'Objects': []}
+            delete_keys['Objects'] = [{'Key': k} for k in key_list[i:i+max_keys_num]]
             result.append(self.cos_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
         return result
-            
+
     def bucket_exists(self, bucket_name):
         """
         Head bucket from COS with a name. Throws StorageNoSuchKeyError if the given bucket does not exist.
@@ -179,12 +174,12 @@ class COSBackend:
                 page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
             else:
                 page_iterator = paginator.paginate(Bucket=bucket_name)
-                
+
             object_list = []
             for page in page_iterator:
                 if 'Contents' in page:
                     for item in page['Contents']:
-                        object_list.append(item)    
+                        object_list.append(item)
             return object_list
         except ibm_botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':

--- a/runtime/deploy_runtime
+++ b/runtime/deploy_runtime
@@ -2,7 +2,6 @@
 import os
 import sys
 import click
-import pkgutil
 import pywren_ibm_cloud as pywren
 from pywren_ibm_cloud import wrenconfig
 from pywren_ibm_cloud.storage import storage
@@ -33,38 +32,33 @@ def create_zip_action():
 def extract_modules(image_name):
     # Extract installed Python modules from docker image
     # And store them into storage
-    
+
     # Create runtime_name from image_name
     username, appname = image_name.split('/')
     runtime_name = appname.replace(':', '_')
-    
+
     # Load PyWren config from ~/.pywren_config
     config = wrenconfig.default()
 
     # Create storage_handler to upload modules file
     storage_config = wrenconfig.extract_storage_config(config)
     internal_storage = storage.InternalStorage(storage_config)
-    
+
     print('Creating and uploading modules file...')
-    
-    runtime_meta = default_preinstalls.modules['pywren_3.6']
-    internal_storage.put_runtime_info(runtime_name, runtime_meta)
-    
-    def extract_python_modules(input=None):
-        runtime_meta = dict()
-        mods = list(pkgutil.iter_modules())
-        runtime_meta['preinstalls'] = [entry for entry in sorted([[mod, is_pkg] for _,mod,is_pkg in mods])]
-        python_version = sys.version_info
-        runtime_meta['python_ver'] = str(python_version[0])+"."+str(python_version[1])
-        
-        return runtime_meta
 
-    pw = pywren.ibm_cf_executor(runtime=runtime_name, log_level='ERROR')
-    pw.call_async(extract_python_modules, [])
-    runtime_meta = pw.get_result()
-    pw.clean()
+    sys.stdout = open(os.devnull, 'w')
+    with open("extract_modules.py", "r") as action_py:
+        action_code = action_py.read()
+    cf_client = CloudFunctions(config['ibm_cf'])
+    action_name = runtime_name+'_modules'
+    cf_client.create_action(action_name, memory=512, timeout=300000,
+                            code=action_code, kind='blackbox',
+                            image=image_name, is_binary=False)
 
+    runtime_meta = cf_client.invoke_with_result(action_name)
     internal_storage.put_runtime_info(runtime_name, runtime_meta)
+    cf_client.delete_action(action_name)
+    sys.stdout = sys.__stdout__
 
 
 def create_blackbox_runtime(image_name):

--- a/runtime/extract_modules.py
+++ b/runtime/extract_modules.py
@@ -1,0 +1,12 @@
+import sys
+import pkgutil
+
+
+def main(args):
+    runtime_meta = dict()
+    mods = list(pkgutil.iter_modules())
+    runtime_meta['preinstalls'] = [entry for entry in sorted([[mod, is_pkg] for _, mod, is_pkg in mods])]
+    python_version = sys.version_info
+    runtime_meta['python_ver'] = str(python_version[0])+"."+str(python_version[1])
+
+    return runtime_meta


### PR DESCRIPTION
Now deploy_runtime script allows to clone any docker image built from any Python version. Previously, the command could only clone images of the same version of local Python.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

