### PR TITLE
list argument fix

### DIFF
--- a/pywren/pywren_ibm_cloud/wrenutil.py
+++ b/pywren/pywren_ibm_cloud/wrenutil.py
@@ -276,7 +276,7 @@ def verify_args(func, data, object_processing=False):
                                  "the args must be: {}".format(list(elem.keys()),
                                                                list(new_func_sig.parameters.keys())))
         elif type(elem) in (list, tuple):
-            new_elem = dict(new_func_sig.bind(*list(elem)).arguments)
+            new_elem = dict(new_func_sig.bind(*[elem]).arguments)
             new_data.append(new_elem)
         else:
             # single value (string, integer, list, etc)


### PR DESCRIPTION
when calling map function with iterable data as arguments to the the function, pywren interprets data wrong. 