### PR TITLE
Enable rabbitmq to track finished function activations

### DIFF
--- a/pywren/ibmcf/default_config.yaml.template
+++ b/pywren/ibmcf/default_config.yaml.template
@@ -28,5 +28,5 @@ ibm_cos:
     #project_id : <SWIFT_PROJECT_ID>
     #password   : <SWIFT_PASSWORD>
 
-rabbitmq:
-	amqp_url 	: <RABBIT_AMQP_URL>  # amqp://
+#rabbitmq:
+	#amqp_url 	: <RABBIT_AMQP_URL>  # amqp://

--- a/pywren/ibmcf/default_config.yaml.template
+++ b/pywren/ibmcf/default_config.yaml.template
@@ -27,3 +27,6 @@ ibm_cos:
     #user_id    : <SWIFT_USER_ID>
     #project_id : <SWIFT_PROJECT_ID>
     #password   : <SWIFT_PASSWORD>
+
+rabbitmq:
+	amqp_url 	: <RABBIT_AMQP_URL>  # amqp://

--- a/pywren/pywren_ibm_cloud/action/jobrunner.py
+++ b/pywren/pywren_ibm_cloud/action/jobrunner.py
@@ -30,7 +30,7 @@ from pywren_ibm_cloud.libs.tblib import pickling_support
 from pywren_ibm_cloud.wrenutil import get_current_memory_usage
 from pywren_ibm_cloud.storage.backends.cos import COSBackend
 from pywren_ibm_cloud.storage.backends.swift import SwiftBackend
-
+from pywren_ibm_cloud.future import ResponseFuture
 
 pickling_support.install()
 level = logging.DEBUG
@@ -49,18 +49,18 @@ def load_config(config_location):
     with open(config_location, 'r') as configf:
         jobrunner_config = json.load(configf)
     return jobrunner_config
-    
-    
+
+
 class stats:
-    
+
     def __init__(self, stats_filename):
         self.stats_filename = stats_filename
         self.stats_fid = open(stats_filename, 'w')
-        
+
     def write(self, key, value):
         self.stats_fid.write("{} {:f}\n".format(key, value))
         self.stats_fid.flush()
-    
+
     def __del__(self):
         self.stats_fid.close()
 
@@ -68,17 +68,17 @@ class stats:
 class jobrunner:
 
     def __init__(self):
-        start_time =  time.time()
+        start_time = time.time()
         self.config = load_config(sys.argv[1])
         self.stats = stats(self.config['stats_filename'])
-        self.stats.write('jobrunner_start', start_time) 
+        self.stats.write('jobrunner_start', start_time)
         self.storage_config = json.loads(os.environ.get('STORAGE_CONFIG', ''))
 
         if 'SHOW_MEMORY_USAGE' in os.environ:
             self.show_memory = eval(os.environ['SHOW_MEMORY_USAGE'])
         else:
             self.show_memory = False
-            
+
         self.func_key = self.config['func_key']
         self.data_key = self.config['data_key']
         self.data_byte_range = self.config['data_byte_range']
@@ -95,22 +95,22 @@ class jobrunner:
         func_download_time_t2 = time.time()
         self.stats.write('func_download_time', func_download_time_t2-func_download_time_t1)
         logger.info("Finished getting Function and modules")
-        
+
         return loaded_func_all
-    
+
     def _save_modules(self, module_data):
         """
         Save modules, before we unpickle actual function
-        """    
+        """
         logger.info("Writing Function dependencies to local disk")
         PYTHON_MODULE_PATH = self.config['python_module_path']
         shutil.rmtree(PYTHON_MODULE_PATH, True)  # delete old modules
         os.mkdir(PYTHON_MODULE_PATH)
         sys.path.append(PYTHON_MODULE_PATH)
-    
+
         for m_filename, m_data in module_data.items():
             m_path = os.path.dirname(m_filename)
-    
+
             if len(m_path) > 0 and m_path[0] == "/":
                 m_path = m_path[1:]
             to_make = os.path.join(PYTHON_MODULE_PATH, m_path)
@@ -130,7 +130,7 @@ class jobrunner:
         #logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))
         #logger.debug(subprocess.check_output("find {}".format(os.getcwd()), shell=True))
         logger.info("Finished writing Function dependencies")
-        
+
     def _unpickle_function(self, pickled_func):
         """
         Unpickle function; it will expect modules to be there
@@ -138,9 +138,9 @@ class jobrunner:
         logger.info("Unpickle Function")
         loaded_func = pickle.loads(pickled_func)
         logger.info("Finished Function unpickle")
-        
+
         return loaded_func
-    
+
     def _load_data(self):
         extra_get_args = {}
         if self.data_byte_range is not None:
@@ -156,34 +156,34 @@ class jobrunner:
         logger.info("Finished unpickle Function data")
         data_download_time_t2 = time.time()
         self.stats.write('data_download_time',
-                   data_download_time_t2-data_download_time_t1)
-        
+                         data_download_time_t2-data_download_time_t1)
+
         return loaded_data
-    
+
     def _create_storage_clients(self, function, data):
         # Verify storage parameters - Create clients
         func_sig = inspect.signature(function)
-    
+
         if 'storage' in func_sig.parameters:
             # 'storage' generic parameter used in map_reduce method
             if 'ibm_cos' in self.storage_config:
                 mr_storage_client = COSBackend(self.storage_config['ibm_cos'])
             elif 'swift' in self.storage_config:
                 mr_storage_client = SwiftBackend(self.storage_config['swift'])
-    
+
             data['storage'] = mr_storage_client
-    
+
         if 'ibm_cos' in func_sig.parameters:
             ibm_boto3_client = COSBackend(self.storage_config['ibm_cos']).get_client()
             data['ibm_cos'] = ibm_boto3_client
-    
+
         if 'swift' in func_sig.parameters:
             swift_client = SwiftBackend(self.storage_config['swift'])
             data['swift'] = swift_client
-    
+
         if 'internal_storage' in func_sig.parameters:
             data['internal_storage'] = self.internal_storage
-        
+
         return data
 
     def run_function(self):
@@ -223,13 +223,21 @@ class jobrunner:
                            'success': True}
             pickled_output = pickle.dumps(output_dict)
 
+            # Check for new futures
+            if isinstance(result, ResponseFuture):
+                self.stats.write('new_futures', 1)
+            elif type(result) == list and len(result) > 0 and isinstance(result[0], ResponseFuture):
+                self.stats.write('new_futures', len(result))
+            else:
+                self.stats.write('new_futures', 0)
+
             if self.show_memory:
                 logger.debug("Memory usage after output serialization: {}".format(get_current_memory_usage()))
-        
+
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             #traceback.print_tb(exc_traceback)
-        
+
             # Shockingly often, modules like subprocess don't properly
             # call the base Exception.__init__, which results in them
             # being unpickleable. As a result, we actually wrap this in a try/catch block
@@ -244,10 +252,10 @@ class jobrunner:
                                                'exc_traceback': exc_traceback,
                                                'sys.path': sys.path,
                                                'success': False})
-        
+
                 # this is just to make sure they can be unpickled
                 pickle.loads(pickled_output)
-        
+
             except Exception as pickle_exception:
                 pickled_output = pickle.dumps({'result': str(e),
                                                'exc_type': str(exc_type),
@@ -262,13 +270,13 @@ class jobrunner:
             store_result = True
             if 'STORE_RESULT' in os.environ:
                 store_result = eval(os.environ['STORE_RESULT'])
-        
+
             if store_result:
                 output_upload_timestamp_t1 = time.time()
                 self.internal_storage.put_data(self.output_key, pickled_output)
                 output_upload_timestamp_t2 = time.time()
                 self.stats.write("output_upload_time",
-                           output_upload_timestamp_t2 - output_upload_timestamp_t1)
+                                 output_upload_timestamp_t2 - output_upload_timestamp_t1)
 
 if __name__ == '__main__':
     logger.info("Jobrunner started")

--- a/pywren/pywren_ibm_cloud/action/jobrunner.py
+++ b/pywren/pywren_ibm_cloud/action/jobrunner.py
@@ -58,7 +58,7 @@ class stats:
         self.stats_fid = open(stats_filename, 'w')
 
     def write(self, key, value):
-        self.stats_fid.write("{} {:f}\n".format(key, value))
+        self.stats_fid.write("{} {}\n".format(key, value))
         self.stats_fid.flush()
 
     def __del__(self):
@@ -225,11 +225,13 @@ class jobrunner:
 
             # Check for new futures
             if isinstance(result, ResponseFuture):
-                self.stats.write('new_futures', 1)
+                callgroup_id = result.callgroup_id
+                self.stats.write('new_futures', '{}/{}'.format(callgroup_id, 1))
             elif type(result) == list and len(result) > 0 and isinstance(result[0], ResponseFuture):
-                self.stats.write('new_futures', len(result))
+                callgroup_id = result[0].callgroup_id
+                self.stats.write('new_futures', '{}/{}'.format(callgroup_id, len(result)))
             else:
-                self.stats.write('new_futures', 0)
+                self.stats.write('new_futures', '{}/{}'.format(None, 0))
 
             if self.show_memory:
                 logger.debug("Memory usage after output serialization: {}".format(get_current_memory_usage()))

--- a/pywren/pywren_ibm_cloud/action/wrenhandler.py
+++ b/pywren/pywren_ibm_cloud/action/wrenhandler.py
@@ -186,8 +186,10 @@ def ibm_cloud_function_handler(event):
             with open(JOBRUNNER_STATS_FILENAME, 'r') as fid:
                 for l in fid.readlines():
                     key, value = l.strip().split(" ")
-                    float_value = float(value)
-                    response_status[key] = float_value
+                    try:
+                        response_status[key] = float(value)
+                    except:
+                        response_status[key] = value
 
         response_status['exec_time'] = time.time() - setup_time
         response_status['host_submit_time'] = event['host_submit_time']
@@ -214,7 +216,7 @@ def ibm_cloud_function_handler(event):
                 status = 'ok'
                 if response_status['exception']:
                     status = 'error'
-                new_futures = int(response_status['new_futures'])
+                new_futures = response_status['new_futures']
                 channel.basic_publish(exchange='', routing_key=executor_id,
                                       body='{}/{}:{}:{}'.format(callgroup_id, call_id,
                                                                 status,  new_futures))

--- a/pywren/pywren_ibm_cloud/action/wrenhandler.py
+++ b/pywren/pywren_ibm_cloud/action/wrenhandler.py
@@ -204,18 +204,20 @@ def ibm_cloud_function_handler(event):
         response_status['exception_traceback'] = traceback.format_exc()
 
     finally:
-        rabbit_amqp_url = config['rabbitmq'].get('amqp_url', None)
-        if rabbit_amqp_url:
-            params = pika.URLParameters(rabbit_amqp_url)
-            connection = pika.BlockingConnection(params)
-            channel = connection.channel()
-            status = 'ok'
-            if response_status['exception']:
-                status = 'error'
-            channel.basic_publish(exchange='', routing_key=executor_id,
-                                  body='{}/{}:{}'.format(callgroup_id, call_id, status))
-            logger.info("Sent response status to queue")
-            connection.close()
+        if 'rabbitmq' in config:
+            rabbit_amqp_url = config['rabbitmq'].get('amqp_url', None)
+            if rabbit_amqp_url:
+                params = pika.URLParameters(rabbit_amqp_url)
+                connection = pika.BlockingConnection(params)
+                channel = connection.channel()
+                channel.queue_declare(queue=executor_id, auto_delete=True)
+                status = 'ok'
+                if response_status['exception']:
+                    status = 'error'
+                channel.basic_publish(exchange='', routing_key=executor_id,
+                                      body='{}/{}:{}'.format(callgroup_id, call_id, status))
+                logger.info("Status sent to rabbitmq")
+                connection.close()
 
         store_status = True
         if 'STORE_STATUS' in extra_env:

--- a/pywren/pywren_ibm_cloud/action/wrenhandler.py
+++ b/pywren/pywren_ibm_cloud/action/wrenhandler.py
@@ -214,8 +214,10 @@ def ibm_cloud_function_handler(event):
                 status = 'ok'
                 if response_status['exception']:
                     status = 'error'
+                new_futures = int(response_status['new_futures'])
                 channel.basic_publish(exchange='', routing_key=executor_id,
-                                      body='{}/{}:{}'.format(callgroup_id, call_id, status))
+                                      body='{}/{}:{}:{}'.format(callgroup_id, call_id,
+                                                                status,  new_futures))
                 logger.info("Status sent to rabbitmq")
                 connection.close()
 

--- a/pywren/pywren_ibm_cloud/cf_connector.py
+++ b/pywren/pywren_ibm_cloud/cf_connector.py
@@ -74,7 +74,7 @@ class CloudFunctions:
 
         limits['timeout'] = self.timeout
         limits['memory'] = self.memory
-            
+
         if limits['timeout'] and limits['memory']:
             data['limits'] = limits
 
@@ -140,15 +140,13 @@ class CloudFunctions:
             resp_time = format(round(resp.elapsed.total_seconds(), 3), '.3f')
         except:
             return self.remote_invoke(action_name, payload)
-        
+
         if 'activationId' in data:
             log_msg = ('Executor ID {} Function {} - Activation ID: '
                        '{} - Time: {} seconds'.format(exec_id, call_id,
                                                       data["activationId"],
                                                       resp_time))
             logger.debug(log_msg)
-            if logger.getEffectiveLevel() == logging.WARNING:
-                print(log_msg)
             return data["activationId"]
         else:
             logger.debug(data)
@@ -180,20 +178,17 @@ class CloudFunctions:
         except:
             conn.close()
             return self.internal_invoke(action_name, payload)
-            
+
         if 'activationId' in data:
             log_msg = ('Executor ID {} Function {} - Activation ID: '
                        '{} - Time: {} seconds'.format(exec_id, call_id,
                                                       data["activationId"],
                                                       resp_time))
             logger.debug(log_msg)
-            if logger.getEffectiveLevel() == logging.WARNING:
-                print(log_msg)
             return data["activationId"]
         else:
             logger.debug(data)
             return None
-
 
     def invoke_with_result(self, action_name, payload={}):
         """

--- a/pywren/pywren_ibm_cloud/cf_connector.py
+++ b/pywren/pywren_ibm_cloud/cf_connector.py
@@ -138,20 +138,21 @@ class CloudFunctions:
             resp = self.session.post(url, json=payload)
             data = resp.json()
             resp_time = format(round(resp.elapsed.total_seconds(), 3), '.3f')
-            if 'activationId' in data:
-                log_msg = ('Executor ID {} Function {} - Activation ID: '
-                           '{} - Time: {} seconds'.format(exec_id, call_id,
-                                                          data["activationId"],
-                                                          resp_time))
-                logger.debug(log_msg)
-                if logger.getEffectiveLevel() == logging.WARNING:
-                    print(log_msg)
-                return data["activationId"]
-            else:
-                logger.debug(data)
-                return None
         except:
             return self.remote_invoke(action_name, payload)
+        
+        if 'activationId' in data:
+            log_msg = ('Executor ID {} Function {} - Activation ID: '
+                       '{} - Time: {} seconds'.format(exec_id, call_id,
+                                                      data["activationId"],
+                                                      resp_time))
+            logger.debug(log_msg)
+            if logger.getEffectiveLevel() == logging.WARNING:
+                print(log_msg)
+            return data["activationId"]
+        else:
+            logger.debug(data)
+            return None
 
     def internal_invoke(self, action_name, payload):
         """
@@ -163,10 +164,10 @@ class CloudFunctions:
         url = urlparse(os.path.join(self.endpoint, 'api', 'v1', 'namespaces',
                                     self.namespace, 'actions', action_name))
         ctx = ssl._create_unverified_context()
-        conn = http.client.HTTPSConnection(url.netloc, context=ctx)
 
         try:
             start = time.time()
+            conn = http.client.HTTPSConnection(url.netloc, context=ctx)
             conn.request("POST", url.geturl(),
                          body=json.dumps(payload),
                          headers=self.headers)
@@ -176,22 +177,23 @@ class CloudFunctions:
             resp_time = format(round(roundtrip, 3), '.3f')
             data = json.loads(data.decode("utf-8"))
             conn.close()
-
-            if 'activationId' in data:
-                log_msg = ('Executor ID {} Function {} - Activation ID: '
-                           '{} - Time: {} seconds'.format(exec_id, call_id,
-                                                          data["activationId"],
-                                                          resp_time))
-                logger.debug(log_msg)
-                if logger.getEffectiveLevel() == logging.WARNING:
-                    print(log_msg)
-                return data["activationId"]
-            else:
-                logger.debug(data)
-                return None
         except:
             conn.close()
             return self.internal_invoke(action_name, payload)
+            
+        if 'activationId' in data:
+            log_msg = ('Executor ID {} Function {} - Activation ID: '
+                       '{} - Time: {} seconds'.format(exec_id, call_id,
+                                                      data["activationId"],
+                                                      resp_time))
+            logger.debug(log_msg)
+            if logger.getEffectiveLevel() == logging.WARNING:
+                print(log_msg)
+            return data["activationId"]
+        else:
+            logger.debug(data)
+            return None
+
 
     def invoke_with_result(self, action_name, payload={}):
         """

--- a/pywren/pywren_ibm_cloud/executor.py
+++ b/pywren/pywren_ibm_cloud/executor.py
@@ -457,7 +457,7 @@ class Executor(object):
             else:
                 show_memory = False
             # Wait for all results
-            wait(fut_list, executor_id, internal_storage, throw_except=throw_except)
+            wait(fut_list, executor_id, internal_storage, download_results=True, throw_except=throw_except)
             results = [f.result() for f in fut_list if f.done and not f.futures]
             reduce_func_args = {'results': results}
 

--- a/pywren/pywren_ibm_cloud/executor.py
+++ b/pywren/pywren_ibm_cloud/executor.py
@@ -409,7 +409,7 @@ class Executor(object):
         call_result_objs = []
 
         start_inv = time.time()
-        log_msg = 'Executor ID {} Starting function invocation: {}()'.format(self.executor_id, func_name)
+        log_msg = 'Executor ID {} Starting function invocation: {}() - Total: {} activations'.format(self.executor_id, func_name, N)
         logger.debug(log_msg)
         if(logger.getEffectiveLevel() == logging.WARNING):
             print(log_msg)

--- a/pywren/pywren_ibm_cloud/future.py
+++ b/pywren/pywren_ibm_cloud/future.py
@@ -260,14 +260,18 @@ class ResponseFuture:
             if isinstance(function_result, ResponseFuture):
                 self._new_futures = [function_result]
                 self._set_state(JobState.futures)
+                self.invoke_status['status_done_timestamp'] = self.invoke_status['download_output_timestamp']
+                del self.invoke_status['download_output_timestamp']
                 return self._new_futures
-            
+
             elif type(function_result) == list and len(function_result) > 0 \
                  and isinstance(function_result[0], ResponseFuture):
                 self._new_futures = function_result                
                 self._set_state(JobState.futures)
+                self.invoke_status['status_done_timestamp'] = self.invoke_status['download_output_timestamp']
+                del self.invoke_status['download_output_timestamp']
                 return self._new_futures
-            
+
             else:
                 self._return_val = function_result
                 self._set_state(JobState.success)

--- a/pywren/pywren_ibm_cloud/invokers.py
+++ b/pywren/pywren_ibm_cloud/invokers.py
@@ -41,19 +41,19 @@ class IBMCloudFunctionsInvoker:
     def invoke(self, payload):
         """
         Invoke -- return information about this invocation
-        """      
+        """
         act_id = self.client.invoke(self.cf_action_name, payload)
         attempts = 1
-        
+
         while not act_id and self.invocation_retry and attempts < self.retries:
             attempts += 1
             selected_sleep = random.choice(self.retry_sleeps)
             exec_id = payload['executor_id']
             call_id = payload['call_id']
-            
+
             log_msg = ('Executor ID {} Function {} - Invocation failed - retry {} in {} seconds'.format(exec_id, call_id, attempts, selected_sleep))
             logger.debug(log_msg)
-            
+
             time.sleep(selected_sleep)
             act_id = self.client.invoke(self.cf_action_name, payload)
 

--- a/pywren/pywren_ibm_cloud/plots.py
+++ b/pywren/pywren_ibm_cloud/plots.py
@@ -14,15 +14,15 @@ logger = logging.getLogger(__name__)
 
 def create_timeline(dst, name, run_statuses, invoke_statuses):
     results_df = pd.DataFrame(run_statuses)
-    invoke_df = pd.DataFrame(invoke_statuses)
-
-    results_df = pd.concat([results_df, invoke_df], axis=1)
-    Cols = list(results_df.columns)
-    for i, item in enumerate(results_df.columns):
-        if item in results_df.columns[:i]:
-            Cols[i] = "toDROP"
-    results_df.columns = Cols
-    results_df = results_df.drop("toDROP", 1)
+    if invoke_statuses:
+        invoke_df = pd.DataFrame(invoke_statuses)
+        results_df = pd.concat([results_df, invoke_df], axis=1)
+        Cols = list(results_df.columns)
+        for i, item in enumerate(results_df.columns):
+            if item in results_df.columns[:i]:
+                Cols[i] = "toDROP"
+        results_df.columns = Cols
+        results_df = results_df.drop("toDROP", 1)
 
     palette = sns.color_palette("deep", 6)
     time_offset = np.min(results_df.host_submit_time)
@@ -33,13 +33,13 @@ def create_timeline(dst, name, run_statuses, invoke_statuses):
     y = np.arange(total_jobs)
     point_size = 10
 
-    fields = [
-              ('host submit', results_df.host_submit_time - time_offset),
+    fields = [('host submit', results_df.host_submit_time - time_offset),
               ('action start', results_df.start_time - time_offset),
               ('jobrunner start', results_df.jobrunner_start - time_offset),
-              ('action done', results_df.end_time - time_offset),
-              ('results fetched', results_df.download_output_timestamp - time_offset)
-             ]
+              ('action done', results_df.end_time - time_offset)]
+
+    if invoke_statuses:
+        fields.append(('results fetched', results_df.download_output_timestamp - time_offset))
 
     patches = []
     for f_i, (field_name, val) in enumerate(fields):
@@ -61,7 +61,10 @@ def create_timeline(dst, name, run_statuses, invoke_statuses):
     ax.set_yticks(y_ticks)
     ax.set_ylim(-0.02*total_jobs, total_jobs*1.05)
 
-    ax.set_xlim(-1, np.max(results_df.download_output_timestamp - time_offset)*1.35)
+    if invoke_statuses:
+        ax.set_xlim(-1, np.max(results_df.download_output_timestamp - time_offset)*1.35)
+    else:
+        ax.set_xlim(-1, np.max(results_df.end_time - time_offset)*1.35)
     #ax.set_xlim(-0.02, np.max(8))
 
     for y in y_ticks:

--- a/pywren/pywren_ibm_cloud/plots.py
+++ b/pywren/pywren_ibm_cloud/plots.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def create_timeline(dst, name, pw_start_time, run_statuses, invoke_statuses):
     results_df = pd.DataFrame(run_statuses)
-    
+
     if invoke_statuses:
         invoke_df = pd.DataFrame(invoke_statuses)
         results_df = pd.concat([results_df, invoke_df], axis=1)
@@ -72,11 +72,11 @@ def create_timeline(dst, name, pw_start_time, run_statuses, invoke_statuses):
         max_seconds = np.max(results_df.status_done_timestamp - pw_start_time)*1.25
     else:
         max_seconds = np.max(results_df.end_time - pw_start_time)*1.25
-    
+
     xplot_step = int(max_seconds/8)
     x_ticks = np.arange(max_seconds//xplot_step + 2) * xplot_step
     ax.set_xlim(0, max_seconds)
-    
+
     ax.set_xticks(x_ticks)
     for x in x_ticks:
         ax.axvline(x, c='k', alpha=0.2, linewidth=0.8)
@@ -131,7 +131,6 @@ def create_histogram(dst, name, pw_start_time, run_statuses):
 
     #ax.set_xlim(0, x_lim)
     ax.set_xlim(0, np.max(time_hist['end_time'])*3)
-    
     ax.set_ylim(0, len(time_hist['start_time'])*1.05)
     ax.set_xlabel("time (sec)")
 

--- a/pywren/pywren_ibm_cloud/plots.py
+++ b/pywren/pywren_ibm_cloud/plots.py
@@ -57,18 +57,22 @@ def create_timeline(dst, name, pw_start_time, run_statuses, invoke_statuses):
     plot_step = int(np.max([1, total_jobs/32]))
 
     y_ticks = np.arange(total_jobs//plot_step + 2) * plot_step
-
     ax.set_yticks(y_ticks)
     ax.set_ylim(-0.02*total_jobs, total_jobs*1.05)
-
-    if invoke_statuses:
-        ax.set_xlim(0, np.max(results_df.download_output_timestamp - pw_start_time)*1.35)
-    else:
-        ax.set_xlim(0, np.max(results_df.end_time - pw_start_time)*1.35)
-    #ax.set_xlim(-0.02, np.max(8))
-
     for y in y_ticks:
         ax.axhline(y, c='k', alpha=0.1, linewidth=1)
+
+    if invoke_statuses:
+        max_seconds = np.max(results_df.download_output_timestamp - pw_start_time)*1.25
+        xplot_step = int(max_seconds/8)
+        x_ticks = np.arange(max_seconds//xplot_step + 2) * xplot_step
+        ax.set_xlim(0, max_seconds)
+    else:
+        x_ticks = np.arange(np.max(results_df.end_time - pw_start_time)*1.35)
+        ax.set_xlim(0, np.max(results_df.end_time - pw_start_time)*1.35)
+    ax.set_xticks(x_ticks)
+    for x in x_ticks:
+        ax.axvline(x, c='k', alpha=0.2, linewidth=0.8)
 
     ax.grid(False)
     fig.tight_layout()

--- a/pywren/pywren_ibm_cloud/plots.py
+++ b/pywren/pywren_ibm_cloud/plots.py
@@ -40,7 +40,6 @@ def create_timeline(dst, name, pw_start_time, run_statuses, invoke_statuses):
               ('action done', results_df.end_time - pw_start_time)]
 
     if 'download_output_timestamp' in results_df:
-        print(results_df.download_output_timestamp)
         fields.append(('results fetched', results_df.download_output_timestamp - pw_start_time))
     elif 'status_done_timestamp' in results_df:
         fields.append(('status fetched', results_df.status_done_timestamp - pw_start_time))

--- a/pywren/pywren_ibm_cloud/wait.py
+++ b/pywren/pywren_ibm_cloud/wait.py
@@ -65,7 +65,7 @@ def wait(fs, executor_id, internal_storage, download_results=False,
 
     if return_when == ALL_COMPLETED:
 
-        if rabbit_amqp_url:
+        if rabbit_amqp_url and not download_results:
             callgroup_id = fs[0].callgroup_id
             return _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, N)
 

--- a/pywren/pywren_ibm_cloud/wait.py
+++ b/pywren/pywren_ibm_cloud/wait.py
@@ -137,7 +137,7 @@ class rabbitmq_checker_worker(threading.Thread):
         self.channel.basic_consume(self.callback, queue=self.executor_id, no_ack=True)
 
     def run(self):
-        msg = 'Executor ID {} Start consuming'.format(self.executor_id)
+        msg = 'Executor ID {} Start consuming from rabbitmq queue'.format(self.executor_id)
         logger.debug(msg)
         self.channel.start_consuming()
 

--- a/pywren/pywren_ibm_cloud/wait.py
+++ b/pywren/pywren_ibm_cloud/wait.py
@@ -20,7 +20,6 @@ import queue
 import random
 import logging
 import threading
-import functools
 from multiprocessing.pool import ThreadPool
 
 logger = logging.getLogger(__name__)
@@ -42,7 +41,7 @@ def wait(fs, executor_id, internal_storage, download_results=False,
     :param fs: A list of futures.
     :param executor_id: executor's ID.
     :param internal_storage: Storage handler to poll cloud storage.
-    :param download_results: Download the results.
+    :param download_results: Download the results: Ture, False.
     :param rabbit_amqp_url: amqp url for accessing rabbitmq.
     :param pbar: Progress bar.
     :param return_when: One of `ALL_COMPLETED`, `ANY_COMPLETED`, `ALWAYS`

--- a/pywren/pywren_ibm_cloud/wait.py
+++ b/pywren/pywren_ibm_cloud/wait.py
@@ -62,18 +62,21 @@ def wait(fs, executor_id, internal_storage, throw_except=True,
     RANDOM_QUERY = False
 
     if return_when == ALL_COMPLETED:
+
+        if rabbit_amqp_url:
+            return _wait_rabbitmq__queue(executor_id, rabbit_amqp_url, pbar, N)
+
         result_count = 0
 
         while result_count < N:
-            fs_dones, fs_notdones = _wait(fs, executor_id,
-                                          internal_storage,
-                                          throw_except,
-                                          rabbit_amqp_url,
-                                          RETURN_EARLY_N,
-                                          MAX_DIRECT_QUERY_N,
-                                          random_query=RANDOM_QUERY,
-                                          THREADPOOL_SIZE=THREADPOOL_SIZE,
-                                          pbar=pbar)
+            fs_dones, fs_notdones = _wait_storage(fs, executor_id,
+                                                  internal_storage,
+                                                  throw_except,
+                                                  RETURN_EARLY_N,
+                                                  MAX_DIRECT_QUERY_N,
+                                                  random_query=RANDOM_QUERY,
+                                                  THREADPOOL_SIZE=THREADPOOL_SIZE,
+                                                  pbar=pbar)
             N = len(fs)
             if pbar and pbar.total != N:
                 pbar.total = N
@@ -87,14 +90,13 @@ def wait(fs, executor_id, internal_storage, throw_except=True,
 
     elif return_when == ANY_COMPLETED:
         while True:
-            fs_dones, fs_notdones = _wait(fs, executor_id,
-                                          internal_storage,
-                                          throw_except,
-                                          rabbit_amqp_url,
-                                          RETURN_EARLY_N,
-                                          MAX_DIRECT_QUERY_N,
-                                          random_query=RANDOM_QUERY,
-                                          THREADPOOL_SIZE=THREADPOOL_SIZE)
+            fs_dones, fs_notdones = _wait_storage(fs, executor_id,
+                                                  internal_storage,
+                                                  throw_except,
+                                                  RETURN_EARLY_N,
+                                                  MAX_DIRECT_QUERY_N,
+                                                  random_query=RANDOM_QUERY,
+                                                  THREADPOOL_SIZE=THREADPOOL_SIZE)
 
             if len(fs_dones) != 0:
                 return fs_dones, fs_notdones
@@ -102,13 +104,13 @@ def wait(fs, executor_id, internal_storage, throw_except=True,
                 time.sleep(WAIT_DUR_SEC)
 
     elif return_when == ALWAYS:
-        return _wait(fs, executor_id,
-                     internal_storage,
-                     throw_except,
-                     RETURN_EARLY_N,
-                     MAX_DIRECT_QUERY_N,
-                     random_query=RANDOM_QUERY,
-                     THREADPOOL_SIZE=THREADPOOL_SIZE)
+        return _wait_storage(fs, executor_id,
+                             internal_storage,
+                             throw_except,
+                             RETURN_EARLY_N,
+                             MAX_DIRECT_QUERY_N,
+                             random_query=RANDOM_QUERY,
+                             THREADPOOL_SIZE=THREADPOOL_SIZE)
     else:
         raise ValueError()
 
@@ -116,8 +118,7 @@ def wait(fs, executor_id, internal_storage, throw_except=True,
 class rabbitmq_checker_worker(threading.Thread):
 
     def callback(self, ch, method, properties, body):
-        #print(" [x] %r" % body)
-        self.q.put(body)
+        self.q.put(body.decode("utf-8"))
 
     def __init__(self, executor_id, rabbit_amqp_url, q):
         threading.Thread.__init__(self)
@@ -135,9 +136,33 @@ class rabbitmq_checker_worker(threading.Thread):
         self.channel.start_consuming()
 
 
-def _wait(fs, executor_id, internal_storage, throw_except,
-          rabbit_amqp_url, return_early_n, max_direct_query_n,
-          random_query=False, THREADPOOL_SIZE=16, pbar=None):
+def _wait_rabbitmq__queue(executor_id, rabbit_amqp_url, pbar, total):
+    q = queue.Queue()
+    td = rabbitmq_checker_worker(executor_id, rabbit_amqp_url, q)
+    td.setDaemon(True)
+    td.start()
+
+    done_call_ids = []
+    while len(done_call_ids) < total:
+        data = q.get().split(':')
+        done_call_ids.append(data[0])
+        if pbar:
+            pbar.update(1)
+            pbar.refresh()
+        new_futures = int(data[-1])
+        total = total + new_futures
+        if pbar and pbar.total != total:
+            pbar.total = total
+            pbar.refresh()
+
+    if pbar:
+        pbar.close()
+
+    return done_call_ids, None
+
+
+def _wait_storage(fs, executor_id, internal_storage, throw_except, return_early_n,
+                  max_direct_query_n, random_query=False, THREADPOOL_SIZE=16, pbar=None):
     """
     internal function that performs the majority of the WAIT task
     work.
@@ -154,100 +179,83 @@ def _wait(fs, executor_id, internal_storage, throw_except,
     random_query decides whether we get the fs in the order they are presented
     or in a random order.
     """
-    if rabbit_amqp_url:
-        q = queue.Queue()
-        td = rabbitmq_checker_worker(executor_id, rabbit_amqp_url, q)
-        td.setDaemon(True)
-        td.start()
-        
-        done_call_ids = []
-        while len(done_call_ids) < len(fs):
-            data = q.get()
-            done_call_ids.append(data)
-            if pbar:
-                pbar.update(1)
-                pbar.refresh()
-        
-        return done_call_ids, None
-        
-    else:
-        # get all the futures that are not yet done
-        not_done_futures = [f for f in fs if not f.done]
-        if len(not_done_futures) == 0:
-            return fs, []
-    
-        # note this returns everything done, so we have to figure out
-        # the intersection of those that are done
-        callids_done_in_callset = set(internal_storage.get_callset_status(executor_id))
-        #print('CALLSET:', callids_done_in_callset, len(callids_done_in_callset))
-    
-        not_done_call_ids = set([(f.callgroup_id, f.call_id) for f in not_done_futures])
-        #print('NO TDONE:' ,not_done_call_ids, len(not_done_call_ids))
-    
-        done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
-        not_done_call_ids = not_done_call_ids - done_call_ids
-        still_not_done_futures = [f for f in not_done_futures if ((f.callgroup_id, f.call_id) in not_done_call_ids)]
-    
-        def fetch_future_status(f):
-            return internal_storage.get_call_status(f.executor_id, f.callgroup_id, f.call_id)
-    
-        pool = ThreadPool(THREADPOOL_SIZE)
-    
-        # now try up to max_direct_query_n direct status queries, quitting once
-        # we have return_n done.
-        query_count = 0
-        max_queries = min(max_direct_query_n, len(still_not_done_futures))
-    
-        if random_query:
-            random.shuffle(still_not_done_futures)
-    
-        while query_count < max_queries:
-            if len(done_call_ids) >= return_early_n:
-                break
-            num_to_query_at_once = THREADPOOL_SIZE
-            fs_to_query = still_not_done_futures[query_count:query_count + num_to_query_at_once]
-            fs_statuses = pool.map(fetch_future_status, fs_to_query)
-    
-            callids_found = [(fs_to_query[i].callgroup_id, fs_to_query[i].call_id) for i in range(len(fs_to_query))
-                             if fs_statuses[i] is not None]
-    
-            #print('FOUND:',callids_found, len(callids_found))
-    
-            done_call_ids = done_call_ids.union(set(callids_found))
-            query_count += len(fs_to_query)
-    
-        # now we walk through all the original queries and get
-        # the ones that are actually done.
-        fs_dones = []
-        fs_notdones = []
-        f_to_wait_on = []
-        for f in fs:
-            if f.done:
-                # done, don't need to do anything
+    # get all the futures that are not yet done
+    not_done_futures = [f for f in fs if not f.done]
+    if len(not_done_futures) == 0:
+        return fs, []
+
+    # note this returns everything done, so we have to figure out
+    # the intersection of those that are done
+    callids_done_in_callset = set(internal_storage.get_callset_status(executor_id))
+    #print('CALLSET:', callids_done_in_callset, len(callids_done_in_callset))
+
+    not_done_call_ids = set([(f.callgroup_id, f.call_id) for f in not_done_futures])
+    #print('NO TDONE:' ,not_done_call_ids, len(not_done_call_ids))
+
+    done_call_ids = not_done_call_ids.intersection(callids_done_in_callset)
+    not_done_call_ids = not_done_call_ids - done_call_ids
+    still_not_done_futures = [f for f in not_done_futures if ((f.callgroup_id, f.call_id) in not_done_call_ids)]
+
+    def fetch_future_status(f):
+        return internal_storage.get_call_status(f.executor_id, f.callgroup_id, f.call_id)
+
+    pool = ThreadPool(THREADPOOL_SIZE)
+
+    # now try up to max_direct_query_n direct status queries, quitting once
+    # we have return_n done.
+    query_count = 0
+    max_queries = min(max_direct_query_n, len(still_not_done_futures))
+
+    if random_query:
+        random.shuffle(still_not_done_futures)
+
+    while query_count < max_queries:
+        if len(done_call_ids) >= return_early_n:
+            break
+        num_to_query_at_once = THREADPOOL_SIZE
+        fs_to_query = still_not_done_futures[query_count:query_count + num_to_query_at_once]
+        fs_statuses = pool.map(fetch_future_status, fs_to_query)
+
+        callids_found = [(fs_to_query[i].callgroup_id, fs_to_query[i].call_id) for i in range(len(fs_to_query))
+                         if fs_statuses[i] is not None]
+
+        #print('FOUND:',callids_found, len(callids_found))
+
+        done_call_ids = done_call_ids.union(set(callids_found))
+        query_count += len(fs_to_query)
+
+    # now we walk through all the original queries and get
+    # the ones that are actually done.
+    fs_dones = []
+    fs_notdones = []
+    f_to_wait_on = []
+    for f in fs:
+        if f.done:
+            # done, don't need to do anything
+            fs_dones.append(f)
+        else:
+            if (f.callgroup_id, f.call_id) in done_call_ids:
+                f_to_wait_on.append(f)
                 fs_dones.append(f)
             else:
-                if (f.callgroup_id, f.call_id) in done_call_ids:
-                    f_to_wait_on.append(f)
-                    fs_dones.append(f)
-                else:
-                    fs_notdones.append(f)
-    
-        def get_result(f):
-            f.result(throw_except=throw_except, internal_storage=internal_storage)
-    
-        pool.map(get_result, f_to_wait_on)
-        pool.close()
-        pool.join()
-    
-        for f in f_to_wait_on:
-            if pbar and f.done:
-                pbar.update(1)
-        if pbar:
-            pbar.refresh()
-    
-        # Check for new futures
-        new_futures = [f.result() for f in f_to_wait_on if f.futures]
-        for futures in new_futures:
-            fs.extend(futures)
-    
-        return fs_dones, fs_notdones
+                fs_notdones.append(f)
+
+    def get_result(f):
+        f.result(throw_except=throw_except, internal_storage=internal_storage)
+
+    pool.map(get_result, f_to_wait_on)
+    pool.close()
+    pool.join()
+
+    for f in f_to_wait_on:
+        if pbar and f.done:
+            pbar.update(1)
+    if pbar:
+        pbar.refresh()
+
+    # Check for new futures
+    new_futures = [f.result() for f in f_to_wait_on if f.futures]
+    for futures in new_futures:
+        fs.extend(futures)
+
+    return fs_dones, fs_notdones

--- a/pywren/pywren_ibm_cloud/wait.py
+++ b/pywren/pywren_ibm_cloud/wait.py
@@ -141,6 +141,9 @@ class rabbitmq_checker_worker(threading.Thread):
         logger.debug(msg)
         self.channel.start_consuming()
 
+    def stop(self):
+        self.channel.close()
+
 
 def _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, total):
     q = queue.Queue()
@@ -187,6 +190,7 @@ def _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, total):
                 pbar.total = pbar.total + total_new_futures
                 pbar.refresh()
 
+    td.stop()
         #print(done_call_ids)
 
     if pbar:

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import time
 import enum
 import json
 import signal
@@ -54,6 +55,7 @@ class ibm_cf_executor:
           >>> import pywren_ibm_cloud as pywren
           >>> pw = pywren.ibm_cf_executor()
         """
+        self.start_time = time.time()
         self._state = ExecutorState.new
 
         if config is None:
@@ -228,6 +230,11 @@ class ibm_cf_executor:
         if not futures:
             raise Exception('No activations to track. You must run pw.call_async(),'
                             ' pw.map() or pw.map_reduce() before call pw.wait()')
+        
+        msg = 'Executor ID {} Waiting for functions to complete'.format(self.executor_id)
+        logger.debug(msg)
+        if logger.getEffectiveLevel() == logging.WARNING:
+            print(msg)
 
         rabbit_amqp_url = self.config['rabbitmq'].get('amqp_url', None)
 
@@ -365,8 +372,8 @@ class ibm_cf_executor:
         if not run_statuses:
             raise Exception('You must provide run_statuses')
 
-        create_timeline(dst, name, run_statuses, invoke_statuses)
-        create_histogram(dst, name, run_statuses, x_lim=150)
+        create_timeline(dst, name, self.start_time, run_statuses, invoke_statuses)
+        create_histogram(dst, name, self.start_time, run_statuses)
 
     def clean(self, local_execution=True):
         """

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -236,7 +236,7 @@ class ibm_cf_executor:
         if logger.getEffectiveLevel() == logging.WARNING:
             print(msg)
 
-        rabbit_amqp_url = self.config['rabbitmq'].get('amqp_url', None)
+        rabbit_amqp_url = self.config['rabbitmq'].get('amqp_url')
 
         pbar = None
         if not self.cf_cluster and logger.getEffectiveLevel() == logging.WARNING and return_when == ALL_COMPLETED:

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -79,8 +79,8 @@ class ibm_cf_executor:
 
         if not use_rabbitmq:
             self.config['rabbitmq']['amqp_url'] = None
-        else:
-            logger.debug('Going to use RabbitMQ to track function activations')
+        elif self.config['rabbitmq']['amqp_url']:
+            logger.info('Going to use RabbitMQ to track function activations')
 
         retry_config = {}
         retry_config['invocation_retry'] = self.config['pywren']['invocation_retry']

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -206,7 +206,7 @@ class ibm_cf_executor:
 
         self._state = ExecutorState.running
         if reducer_wait_local:
-            self.wait(futures=map_futures)
+            self.monitor(futures=map_futures)
 
         futures = self.executor.reduce(reduce_function, map_futures, parts_per_object,
                                        reducer_one_per_object, extra_env, extra_meta)
@@ -216,8 +216,8 @@ class ibm_cf_executor:
             return futures[0]
         return futures
 
-    def wait(self, futures=None, throw_except=True, return_when=ALL_COMPLETED,
-             download_results=False, THREADPOOL_SIZE=128, WAIT_DUR_SEC=1):
+    def monitor(self, futures=None, throw_except=True, return_when=ALL_COMPLETED,
+                download_results=False, THREADPOOL_SIZE=128, WAIT_DUR_SEC=1):
         """
         Wait for the Future instances `fs` to complete. Returns a 2-tuple of
         lists. The first list contains the futures that completed
@@ -398,12 +398,12 @@ class ibm_cf_executor:
                                 ' before call pw.create_timeline_plots()')
 
             if self._state == ExecutorState.running:
-                # wait() method not executed at any time
-                self.wait()
+                # monitor() method not executed at any time
+                self.monitor()
             if self._state == ExecutorState.ready:
                 # wait() method already executed. Download statuses from storage
                 self.use_rabbitmq = False
-                self.wait()
+                self.monitor()
 
             if self.futures:
                 run_statuses = [f.run_status for f in self.futures]

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -115,8 +115,8 @@ class ibm_cf_executor:
         return future
 
     def map(self, map_function, map_iterdata, extra_env=None, extra_meta=None,
-            remote_invocation=False, invoke_pool_threads=10, data_all_as_one=True,
-            overwrite_invoke_args=None, exclude_modules=None):
+            remote_invocation=False, remote_invocation_groups=100, invoke_pool_threads=128,
+            data_all_as_one=True, overwrite_invoke_args=None, exclude_modules=None):
         """
         :param func: the function to map over the data
         :param iterdata: An iterable of input data
@@ -143,6 +143,7 @@ class ibm_cf_executor:
                                               extra_env=extra_env,
                                               extra_meta=extra_meta,
                                               remote_invocation=remote_invocation,
+                                              remote_invocation_groups=remote_invocation_groups,
                                               invoke_pool_threads=invoke_pool_threads,
                                               data_all_as_one=data_all_as_one,
                                               overwrite_invoke_args=overwrite_invoke_args,

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -230,7 +230,7 @@ class ibm_cf_executor:
         if not futures:
             raise Exception('No activations to track. You must run pw.call_async(),'
                             ' pw.map() or pw.map_reduce() before call pw.wait()')
-        
+
         msg = 'Executor ID {} Waiting for functions to complete'.format(self.executor_id)
         logger.debug(msg)
         if logger.getEffectiveLevel() == logging.WARNING:
@@ -239,12 +239,12 @@ class ibm_cf_executor:
         rabbit_amqp_url = self.config['rabbitmq'].get('amqp_url', None)
 
         pbar = None
-        if not self.cf_cluster and logger.getEffectiveLevel() == logging.WARNING:
+        if not self.cf_cluster and logger.getEffectiveLevel() == logging.WARNING and return_when == ALL_COMPLETED:
             import tqdm
             print()
             pbar = tqdm.tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ',
                              total=len(futures), disable=False)
-        
+
         fs_dones, fs_notdones = wait(futures, self.executor_id, self.internal_storage,
                                      throw_except=throw_except, return_when=return_when,
                                      rabbit_amqp_url=rabbit_amqp_url, pbar=pbar,
@@ -343,7 +343,7 @@ class ibm_cf_executor:
                 print()
             if self.data_cleaner and not self.cf_cluster:
                 self.clean()
-            self._state == ExecutorState.finished
+            self._state = ExecutorState.finished
 
         msg = "Executor ID {} Finished\n".format(self.executor_id)
         logger.debug(msg)

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -337,12 +337,12 @@ class ibm_cf_executor:
         """
         from pywren_ibm_cloud.plots import create_timeline, create_histogram
 
-        if self.futures and not run_statuses and not invoke_statuses:
+        if self.futures and not run_statuses:
             run_statuses = [f.run_status for f in self.futures]
             invoke_statuses = [f.invoke_status for f in self.futures]
 
-        if not run_statuses and not invoke_statuses:
-            raise Exception('You must provide run_statuses and invoke_statuses')
+        if not run_statuses:
+            raise Exception('You must provide run_statuses')
 
         create_timeline(dst, name, run_statuses, invoke_statuses)
         create_histogram(dst, name, run_statuses, x_lim=150)

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -380,6 +380,8 @@ class ibm_cf_executor:
         if logger.getEffectiveLevel() == logging.WARNING:
             print(msg)
 
+        rabbitmq_used = self.use_rabbitmq
+
         if not run_statuses:
             if self._state == ExecutorState.new or self._state == ExecutorState.error:
                 raise Exception('You must run pw.call_async(), pw.map() or pw.map_reduce()'
@@ -399,7 +401,7 @@ class ibm_cf_executor:
                 logger.debug('No futures available to print the plots')
                 return
 
-            if self.use_rabbitmq and self.config['rabbitmq']['amqp_url'] and invoke_statuses:
+            if rabbitmq_used and self.config['rabbitmq']['amqp_url'] and invoke_statuses:
                 # delete download ststus timestamp
                 for in_stat in invoke_statuses:
                     del in_stat['status_done_timestamp']

--- a/pywren/pywren_ibm_cloud/wren.py
+++ b/pywren/pywren_ibm_cloud/wren.py
@@ -79,6 +79,8 @@ class ibm_cf_executor:
 
         if not use_rabbitmq:
             self.config['rabbitmq']['amqp_url'] = None
+        else:
+            logger.debug('Going to use RabbitMQ to track function activations')
 
         retry_config = {}
         retry_config['invocation_retry'] = self.config['pywren']['invocation_retry']

--- a/pywren/pywren_ibm_cloud/wrenconfig.py
+++ b/pywren/pywren_ibm_cloud/wrenconfig.py
@@ -30,6 +30,7 @@ MAX_AGG_DATA_SIZE = 4e6
 INVOCATION_RETRY_DEFAULT = True
 RETRY_SLEEPS_DEFAULT = [1, 5, 10, 20, 30]
 RETRIES_DEFAULT = 5
+AMQP_URL_DEFAULT = None
 
 
 def load(config_filename):
@@ -143,6 +144,11 @@ def default(config_data=None):
 
     if 'action_timeout' not in config_data['ibm_cf']:
         config_data['ibm_cf']['action_timeout'] = CF_ACTION_TIMEOUT_DEFAULT
+
+    if 'rabbitmq' not in config_data or not config_data['rabbitmq'] \
+       or 'amqp_url' not in config_data['rabbitmq']:
+        config_data['rabbitmq'] = {}
+        config_data['rabbitmq']['amqp_url'] = None
 
     # True or False depending on whether this code is executed within CF cluster or not
     config_data['ibm_cf']['is_cf_cluster'] = is_cf_cluster()

--- a/pywren/pywren_ibm_cloud/wrenutil.py
+++ b/pywren/pywren_ibm_cloud/wrenutil.py
@@ -48,6 +48,11 @@ def is_cf_cluster():
     return False
 
 
+def is_object_processing(map_function):
+    func_sig = inspect.signature(map_function)
+    return {'bucket', 'key', 'url'} & set(func_sig.parameters)
+
+
 def iterdata_as_list(iterdata):
     """
     Converts iteradat to a list
@@ -57,7 +62,7 @@ def iterdata_as_list(iterdata):
     elif type(iterdata) != list:
         return list(iterdata)
     else:
-        return iterdata 
+        return iterdata
 
 
 def convert_bools_to_string(extra_env):
@@ -72,7 +77,7 @@ def convert_bools_to_string(extra_env):
 
 
 def sizeof_fmt(num, suffix='B'):
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
         if abs(num) < 1024.0:
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
@@ -157,7 +162,7 @@ class WrappedStreamingBody:
 
 
 class WrappedStreamingBodyThreshold(WrappedStreamingBody):
-    
+
     def __init__(self, sb, size, threshold):
         # The StreamingBody we're wrapping
         self.sb = sb
@@ -183,7 +188,7 @@ class WrappedStreamingBodyThreshold(WrappedStreamingBody):
 
 def sdb_to_dict(item):
     attr = item['Attributes']
-    return {c['Name'] : c['Value'] for c in attr}
+    return {c['Name']: c['Value'] for c in attr}
 
 
 def bytes_to_b64str(byte_data):
@@ -201,7 +206,6 @@ def b64str_to_bytes(str_data):
 def split_s3_url(s3_url):
     if s3_url[:5] != "s3://":
         raise ValueError("URL {} is not valid".format(s3_url))
-
 
     splits = s3_url[5:].split("/")
     bucket_name = splits[0]
@@ -242,7 +246,7 @@ def verify_args(func, data, object_processing=False):
     # Verify parameters
     none_verify_parameters = ['storage', 'ibm_cos', 'swift', 'internal_storage']
     func_sig = inspect.signature(func)
-    
+
     # Check mandatory parameters in function
     if object_processing:
         none_verify_parameters.append('data_stream')
@@ -257,7 +261,7 @@ def verify_args(func, data, object_processing=False):
         if 'key' in func_sig.parameters or 'url' in func_sig.parameters:
             if 'data_stream' not in func_sig.parameters:
                 raise ValueError('"data_stream" {}'.format(err_msg))
-        
+
     new_parameters = list()
     for param in func_sig.parameters:
         if func_sig.parameters[param].default != None and param not in none_verify_parameters:
@@ -271,8 +275,8 @@ def verify_args(func, data, object_processing=False):
             if set(list(new_func_sig.parameters.keys())) <= set(elem):
                 new_data.append(elem)
             else:
-                raise ValueError("Check the args names in the data. " \
-                                 "You provided these args: {}, and " \
+                raise ValueError("Check the args names in the data. "
+                                 "You provided these args: {}, and "
                                  "the args must be: {}".format(list(elem.keys()),
                                                                list(new_func_sig.parameters.keys())))
         elif type(elem) in (list, tuple):

--- a/pywren/setup.py
+++ b/pywren/setup.py
@@ -40,7 +40,7 @@ setup(
     author_email='jonas@ericjonas.com',
     packages=find_packages(),
     install_requires=[
-        'Click', 'ibm-cos-sdk', 'PyYAML',
+        'Click', 'ibm-cos-sdk', 'PyYAML', 'pika',
         'enum34', 'glob2', 'tqdm', 'tblib',
         'requests', 'python-dateutil', 'lxml',
         'pandas', 'seaborn', 'matplotlib'

--- a/runtime/requirements.txt
+++ b/runtime/requirements.txt
@@ -1,44 +1,44 @@
 # Requirements.txt contains a list of dependencies for the Python Application #
 
 # Setup modules
-gevent == 1.3.7
+gevent == 1.4.0
 flask == 1.0.2
 
 # default available packages for python3action
-beautifulsoup4 == 4.6.3
-httplib2 == 0.11.3
+beautifulsoup4 == 4.7.1
+httplib2 == 0.12.0
 kafka_python == 1.4.4
-lxml == 4.2.5
+lxml == 4.3.0
 python-dateutil == 2.7.5
 requests == 2.21.0
-scrapy == 1.5.1
+scrapy == 1.6.0
 simplejson == 3.16.0
-virtualenv == 16.1.0
+virtualenv == 16.3.0
 twisted == 18.9.0
 
 # packages for numerics
-numpy == 1.15.4
-scikit-learn == 0.20.1
-scipy == 1.1.0
-pandas == 0.23.4
+numpy == 1.16.1
+scikit-learn == 0.20.2
+scipy == 1.2.0
+pandas == 0.24.1
 
 # packages for image processing
-Pillow == 5.3.0
+Pillow == 5.4.1
 
 # IBM specific python modules
 ibm_db == 2.0.9
-cloudant == 2.10.1
+cloudant == 2.11.0
 # pin watson at 1.x, for 2.x use python:3.7 runtime
 watson-developer-cloud == 1.7.1
-ibm-cos-sdk == 2.4.0
+ibm-cos-sdk == 2.4.3
 ibmcloudsql == 0.2.23
 
 # Compose Libs
-psycopg2 == 2.7.6.1
+psycopg2 == 2.7.7
 pymongo == 3.7.2
 # pin redis at 2.x, for 3.x use python:3.7 runtime
 redis == 2.10.6
-pika == 0.12.0
+pika == 0.13.0
 # pin elasticsearch at 5.x, for 6.x use python:3.7 runtime
 elasticsearch >=5.0.0,<6.0.0
 cassandra-driver == 3.16.0


### PR DESCRIPTION
By using this service: https://console.bluemix.net/catalog/services/cloudamqp, it is possible to quickly track the functions that have finished.

Add the AMQP_URL in the config file:
```
rabbitmq: 
     amqp_url : <AMQP_URL>
```
This feature is integrated in the `pw.monitor()` method.
To activate it, use: `pw = pywren.ibm_cf_executor(use_rabbitmq=True)`

If the rabbitmq config is not in the config file, the feature is ignored by PyWren, even if `use_rabbitmq=True`


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

