### PR TITLE
Installation script to support PW version as a parameter

### DIFF
--- a/install_pywren.sh
+++ b/install_pywren.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
-LAST_RELEASE=`wget -q --no-check-certificate https://api.github.com/repos/pywren/pywren-ibm-cloud/releases/latest -O - | grep '"tag_name":' |  sed -E 's/.*"([^"]+)".*/\1/'`
-echo "Installing PyWren for IBM Cloud Functions - Release $LAST_RELEASE ..."
+if [ -z "$1" ]
+then
+    # If no version provided, get last release
+    RELEASE=`wget -q --no-check-certificate https://api.github.com/repos/pywren/pywren-ibm-cloud/releases/latest -O - | grep '"tag_name":' |  sed -E 's/.*"([^"]+)".*/\1/'`
+else
+    RELEASE=$1
+fi
+
+echo "Installing PyWren for IBM Cloud Functions - Release $RELEASE ..."
 rm -rf pywren-ibm-cloud* > /dev/null
-wget --no-check-certificate 'https://github.com/pywren/pywren-ibm-cloud/archive/'$LAST_RELEASE'.zip' -O pywren-ibm-cloud.zip 2> /dev/null
+wget --no-check-certificate 'https://github.com/pywren/pywren-ibm-cloud/archive/'$RELEASE'.zip' -O pywren-ibm-cloud.zip 2> /dev/null
 unzip  pywren-ibm-cloud.zip > /dev/null
-mv pywren-ibm-cloud-$LAST_RELEASE pywren-ibm-cloud
+mv pywren-ibm-cloud-$RELEASE pywren-ibm-cloud
 cd pywren-ibm-cloud/pywren; pip install -U . > /dev/null
 echo "done!"


### PR DESCRIPTION
Installation script now supports PyWren version as an input parameter, for example:
`./install_pywren 1.0.2`
or
`curl -fsSL "https://git.io/fhe9X" | sh /dev/stdin 1.0.2`
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

