### PR TITLE
added boto3 logging option

### DIFF
--- a/pywren/pywren_ibm_cloud/wrenlogging.py
+++ b/pywren/pywren_ibm_cloud/wrenlogging.py
@@ -18,6 +18,11 @@ import logging.config
 
 
 def default_config(log_level='INFO'):
+    if log_level == 'DEBUG_BOTO3':
+        log_level = 'DEBUG'
+        logging.getLogger('ibm_boto3').setLevel(logging.DEBUG)
+        logging.getLogger('ibm_botocore').setLevel(logging.DEBUG)
+
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,


### PR DESCRIPTION
for debugging without boto3 logs:
```python
pw = pywren.ibm_cf_executor(log_level='DEBUG')
```
for debugging with boto3 logs:
```python
pw = pywren.ibm_cf_executor(log_level='DEBUG_BOTO3')
```