### PR TITLE
improve partitioner's time

### DIFF
--- a/pywren/pywren_ibm_cloud/partitioner.py
+++ b/pywren/pywren_ibm_cloud/partitioner.py
@@ -83,7 +83,7 @@ def split_objects_from_bucket(map_func_args_list, chunk_size, storage):
     partitions = []
     parts_per_object = []
 
-    def _split(entry):
+    for entry in map_func_args_list:
         # Each entry is a bucket
         if chunk_size:
             logger.info('Creating chunks from objects within: {}'.format(entry['bucket']))
@@ -92,7 +92,7 @@ def split_objects_from_bucket(map_func_args_list, chunk_size, storage):
         bucket_name, prefix = wrenutil.split_path(entry['bucket'])
         objects = storage.list_objects(bucket_name, prefix)
 
-        for obj in objects:
+        def _split(obj):
             key = obj['Key']
             obj_size = obj['Size']
             total_partitions = 0
@@ -124,10 +124,10 @@ def split_objects_from_bucket(map_func_args_list, chunk_size, storage):
 
             parts_per_object.append(total_partitions)
 
-    pool = ThreadPool(128)
-    pool.map(_split, map_func_args_list)
-    pool.close()
-    pool.join()
+        pool = ThreadPool(128)
+        pool.map(_split, objects)
+        pool.close()
+        pool.join()
 
     return partitions, parts_per_object
 


### PR DESCRIPTION
currently, partitioner gets keys' heads from storage and it takes too long cause it is done sequentially.
improved this by adding ThreadPool support, so partitioner will work in parallel now.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
