### PR TITLE
Enabled memory configuration in the executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-*.pyc
-build/
-dist/
-pywren_ibm_cloud.egg-info

--- a/pywren_ibm_cloud/runtime/deploy_utils.py
+++ b/pywren_ibm_cloud/runtime/deploy_utils.py
@@ -75,7 +75,7 @@ def _extract_modules(image_name, cf_client, config):
     cf_client.delete_action(action_name)
 
 
-def _create_blackbox_runtime(image_name, cf_client):
+def _create_blackbox_runtime(image_name, memory, cf_client):
     # Create runtime_name from image_name
     username, appname = image_name.split('/')
     runtime_name = appname.replace(':', '_')
@@ -83,10 +83,10 @@ def _create_blackbox_runtime(image_name, cf_client):
     # Upload zipped PyWren action
     with open(ZIP_LOCATION, "rb") as action_zip:
         action_bin = action_zip.read()
-    cf_client.create_action(runtime_name, code=action_bin, kind='blackbox', image=image_name)
+    cf_client.create_action(runtime_name, code=action_bin, memory=memory, kind='blackbox', image=image_name)
 
 
-def create_runtime(image_name, config=None):
+def create_runtime(image_name, memory=None, config=None):
     print('Creating a new docker image from the Dockerfile')
     print('Docker image name: {}'.format(image_name))
 
@@ -108,12 +108,12 @@ def create_runtime(image_name, config=None):
     cf_client = CloudFunctions(config['ibm_cf'])
     _create_zip_action()
     _extract_modules(image_name, cf_client, config)
-    _create_blackbox_runtime(image_name, cf_client)
+    _create_blackbox_runtime(image_name, memory, cf_client)
 
     print('All done!')
 
 
-def clone_runtime(image_name, config=None):
+def clone_runtime(image_name, memory=None, config=None):
     print('Cloning docker image {}'.format(image_name))
 
     if config is None:
@@ -124,12 +124,12 @@ def clone_runtime(image_name, config=None):
     cf_client = CloudFunctions(config['ibm_cf'])
     _create_zip_action()
     _extract_modules(image_name, cf_client, config)
-    _create_blackbox_runtime(image_name, cf_client)
+    _create_blackbox_runtime(image_name, memory, cf_client)
 
     print('All done!')
 
 
-def update_runtime(image_name, config=None):
+def update_runtime(image_name, memory=None, config=None):
     print('Updating runtime {}'.format(image_name))
     if config is None:
         config = wrenconfig.default()
@@ -137,12 +137,12 @@ def update_runtime(image_name, config=None):
         config = wrenconfig.default(config)
     cf_client = CloudFunctions(config['ibm_cf'])
     _create_zip_action()
-    _create_blackbox_runtime(image_name, cf_client)
+    _create_blackbox_runtime(image_name, memory, cf_client)
 
     print('All done!')
 
 
-def deploy_default_runtime(config=None):
+def deploy_default_runtime(memory=None, config=None):
     print('Updating runtime {}'.format(CF_ACTION_NAME_DEFAULT))
     if config is None:
         config = wrenconfig.default()
@@ -156,4 +156,4 @@ def deploy_default_runtime(config=None):
         action_bin = action_zip.read()
         cf_client = CloudFunctions(config['ibm_cf'])
         runtime_name = CF_ACTION_NAME_DEFAULT
-        cf_client.create_action(runtime_name, code=action_bin)
+        cf_client.create_action(runtime_name, code=action_bin, memory=memory)

--- a/pywren_ibm_cloud/wren.py
+++ b/pywren_ibm_cloud/wren.py
@@ -44,7 +44,7 @@ class ExecutorState(enum.Enum):
 
 class ibm_cf_executor:
 
-    def __init__(self, config=None, runtime=None, log_level=None, rabbitmq_monitor=False):
+    def __init__(self, config=None, runtime=None, runtime_memory=None, log_level=None, rabbitmq_monitor=False):
         """
         Initialize and return an executor class.
 
@@ -88,7 +88,7 @@ class ibm_cf_executor:
         retry_config['retry_sleeps'] = self.config['pywren']['retry_sleeps']
         retry_config['retries'] = self.config['pywren']['retries']
 
-        invoker = invokers.IBMCloudFunctionsInvoker(ibm_cf_config, retry_config)
+        invoker = invokers.IBMCloudFunctionsInvoker(ibm_cf_config, runtime_memory, retry_config)
 
         self.storage_config = wrenconfig.extract_storage_config(self.config)
         self.internal_storage = storage.InternalStorage(self.storage_config)

--- a/runtime/deploy_runtime
+++ b/runtime/deploy_runtime
@@ -5,27 +5,31 @@ import click
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-def cli(ctx):
+@click.option('--memory', default=None, help='memory used by the runtime', type=int)
+def cli(ctx, memory):
     if ctx.invoked_subcommand is None:
-        deploy_default_runtime()
+        deploy_default_runtime(memory=memory)
 
 
 @cli.command('create')
 @click.argument('image_name')
-def create(image_name):
-    create_runtime(image_name)
+@click.option('--memory', default=None, help='memory used by the runtime', type=int)
+def create(image_name, memory):
+    create_runtime(image_name, memory=memory)
 
 
 @cli.command('clone')
 @click.argument('image_name')
-def clone(image_name):
-    clone_runtime(image_name)
+@click.option('--memory', default=None, help='memory used by the runtime', type=int)
+def clone(image_name, memory):
+    clone_runtime(image_name, memory=memory)
 
 
 @cli.command('update')
 @click.argument('image_name')
-def update(image_name):
-    update_runtime(image_name)
+@click.option('--memory', default=None, help='memory used by the runtime', type=int)
+def update(image_name, memory):
+    update_runtime(image_name, memory=memory)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch allows to introduce the desired runtime memory in the executor and the deployment script. For example:

`pw = pywren.ibm_cf_executor(runtime_memory=128)`

If the variable `runtime_memory `is not set, PW uses the memory set in the config file (Default=512MB)

Also, it is possible to provide memory size in the deployment script:

```
./deploy_runtime --memory 256
./deploy_runtime clone ibmfunctions/pywren-metabolomics:3.6 --memory 1024
```
or:
```
import pywren_ibm_cloud as pywren
pywren.runtime.clone_runtime('ibmfunctions/pywren-metabolomics:3.6', memory=256)
```

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

