### PR TITLE
Added COS private_endpoint parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration keys
 
-Summary of configuration keys:
+Summary of configuration keys for IBM-PyWren:
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
@@ -9,20 +9,34 @@ Summary of configuration keys:
 |pywren|data_cleaner|False|no|If set to True, then cleaner will automatically delete temporary data that was written into `storage_bucket/storage_prefix`|
 |pywren | storage_backend| ibm_cos | no | backend storage implementation. IBM COS is the default |
 |pywren | invocation_retry| True | no | Retry invocation in case of failure |
-|pywren | retry_sleeps | [1, 5, 10, 20, 30] | no | Number of seconds to wait before retry |
+|pywren | retry_sleeps | [1, 5, 10, 15, 20] | no | Number of seconds to wait before retry |
 |pywren| retries | 5 | no | number of retries |
-|ibm_cf| endpoint | | yes | IBM Cloud Functions hostname. Endpoint is the value of 'host' from [api-key](https://console.bluemix.net/openwhisk/learn/api-key). Make sure to use https:// prefix |
-|ibm_cf| namespace | | yes | IBM Cloud Functions namespace. Value of CURRENT NAMESPACE from [api-key](https://console.bluemix.net/openwhisk/learn/api-key) |
-|ibm_cf| api_key | | yes | IBM Cloud Functions api key. Value of api key from [api-key](https://console.bluemix.net/openwhisk/learn/api-key) |
-|ibm_cf| action_timeout | 600000 |no |  Default timeout |
-|ibm_cf| action_memory | 512 | no | Default memory |
-|ibm_cos | endpoint | | yes | Endpoint to your COS account. Make sure to use full path. for example https://s3-api.us-geo.objectstorage.softlayer.net |
+|pywren| runtime_timeout | 600000 |no |  Default timeout |
+|pywren| runtime_memory | 256 | no | Default memory |
+
+
+Summary of configuration keys for IBM Cloud Functions:
+
+|Group|Key|Default|Mandatory|Additional info|
+|---|---|---|---|---|
+|ibm_cf| endpoint | | yes | IBM Cloud Functions hostname. Endpoint is the value of 'HOST' from [api-key](https://cloud.ibm.com/openwhisk/learn/api-key). Make sure to use https:// prefix |
+|ibm_cf| namespace | | yes | IBM Cloud Functions namespace. Value of CURRENT NAMESPACE from [api-key](https://cloud.ibm.com/openwhisk/learn/api-key) |
+|ibm_cf| api_key | | yes | IBM Cloud Functions api key. Value of 'KEY' from [api-key](https://console.bluemix.net/openwhisk/learn/api-key) |
+
+
+Summary of configuration keys for IBM Cloud Object Storage:
+
+|Group|Key|Default|Mandatory|Additional info|
+|---|---|---|---|---|
+|ibm_cos | endpoint | | yes | Regional endpoint to your COS account. Make sure to use full path. For example https://s3.us-east.cloud-object-storage.appdomain.cloud |
+|ibm_cos | private_endpoint | | no | Private regional endpoint to your COS account. Make sure to use full path. For example: https://s3.private.us-east.cloud-object-storage.appdomain.cloud |
 |ibm_cos | api_key | | yes | API Key to your COS account|
-|ibm_cos | `ibm_auth_endpoint` | https://iam.cloud.ibm.com | no | Optional URL for IBM Authentication IAM |
+|ibm_cos | ibm_auth_endpoint | https://iam.cloud.ibm.com/oidc/token | no | Optional URL for IBM Authentication IAM |
 
-### Using in-memory storage for temporary data
 
-You can configure PyWren to use in-memory storage to keep the temporary data. We support currently [CloudAMQP](https://console.bluemix.net/catalog/services/cloudamqp) and more other services will be supported at later stage. To enable PyWren to use this service please setup additional key
+### Using in-memory storage for monitoring function executions
+
+You can configure PyWren to use in-memory storage to monitor function executions in real time. We support currently [CloudAMQP](https://cloud.ibm.com/catalog/services/cloudamqp) and more other services will be supported at later stage. To enable PyWren to use this service please setup additional key.
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|

--- a/pywren_ibm_cloud/action/handler.py
+++ b/pywren_ibm_cloud/action/handler.py
@@ -48,8 +48,9 @@ def free_disk_space(dirname):
 
 
 def get_server_info():
-    server_info = {'hostname': subprocess.check_output("uname -n", shell=True).decode("ascii").strip(),
+    server_info = {'container_name': subprocess.check_output("uname -n", shell=True).decode("ascii").strip(),
                    'ip_address': subprocess.check_output("hostname -I", shell=True).decode("ascii").strip(),
+                   # 'mac_address': subprocess.check_output("cat /sys/class/net/eth0/address", shell=True).decode("ascii").strip(),
                    'net_speed': subprocess.check_output("cat /sys/class/net/eth0/speed | awk '{print $0 / 1000\"GbE\"}'", shell=True).decode("ascii").strip(),
                    'cores': subprocess.check_output("nproc", shell=True).decode("ascii").strip(),
                    'memory': subprocess.check_output("grep MemTotal /proc/meminfo | awk '{print $2 / 1024 / 1024\"GB\"}'", shell=True).decode("ascii").strip()}

--- a/pywren_ibm_cloud/cf_connector.py
+++ b/pywren_ibm_cloud/cf_connector.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 #
 
-import requests
-import base64
 import os
-import json
 import ssl
-from urllib.parse import urlparse
-import http.client
-import logging
+import json
 import time
+import base64
+import logging
+import requests
+import http.client
+from urllib.parse import urlparse
 from pywren_ibm_cloud.version import __version__
+from pywren_ibm_cloud.utils import is_cf_cluster
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,7 @@ class CloudFunctions:
         self.namespace = config['namespace']
         self.default_runtime_memory = int(config['runtime_memory'])
         self.default_runtime_timeout = int(config['runtime_timeout'])
-        self.is_cf_cluster = config['is_cf_cluster']
+        self.is_cf_cluster = is_cf_cluster()
         self.package = 'pywren_v'+__version__
 
         auth = base64.encodebytes(self.api_key).replace(b'\n', b'')

--- a/pywren_ibm_cloud/wrenconfig.py
+++ b/pywren_ibm_cloud/wrenconfig.py
@@ -17,7 +17,7 @@
 import os
 import sys
 import json
-from pywren_ibm_cloud.utils import version_str, is_cf_cluster
+from pywren_ibm_cloud.utils import version_str
 
 STORAGE_BACKEND_DEFAULT = 'ibm_cos'
 COS_BUCKET_DEFAULT = "pywren.data"
@@ -154,9 +154,6 @@ def default(config_data=None):
 
     if 'ibm_cos' in config_data and 'ibm_auth_endpoint' not in config_data['ibm_cos']:
         config_data['ibm_cos']['ibm_auth_endpoint'] = COS_AUTH_ENDPOINT_DEFAULT
-
-    # True or False depending on whether this code is executed within CF cluster or not
-    config_data['ibm_cf']['is_cf_cluster'] = is_cf_cluster()
 
     if 'rabbitmq' not in config_data or not config_data['rabbitmq'] \
        or 'amqp_url' not in config_data['rabbitmq']:


### PR DESCRIPTION
This patch allows to set COS private_endpoint into the config.

It is optional, so if not set, PyWren will continue to use the public endpoint.
If set, all functions will use private_endpoint
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

