### PR TITLE
Improved Function exception management

### DIFF
--- a/pywren_ibm_cloud/action/__main__.py
+++ b/pywren_ibm_cloud/action/__main__.py
@@ -16,7 +16,7 @@
 
 import logging
 from pywren_ibm_cloud import wrenlogging
-from pywren_ibm_cloud.action.handler import ibm_cloud_function_handler
+from pywren_ibm_cloud.action.handler import function_handler
 
 wrenlogging.ow_config(logging.INFO)
 logger = logging.getLogger('__main__')
@@ -24,5 +24,5 @@ logger = logging.getLogger('__main__')
 
 def main(args):
     logger.info("Starting IBM Cloud Function execution")
-    ibm_cloud_function_handler(args)
-    return {"greeting": "Finished"}
+    function_handler(args)
+    return {"Execution": "Finished"}

--- a/pywren_ibm_cloud/action/handler.py
+++ b/pywren_ibm_cloud/action/handler.py
@@ -211,7 +211,7 @@ def function_handler(event):
                     logger.error(str(e))
                     logger.info('Retrying to send stats to rabbitmq...')
                     time.sleep(0.2)
-        elif store_status:
+        if store_status:
             internal_storage = storage.InternalStorage(storage_config)
             logger.info("Storing execution stats - status.json - Size: {}".format(drs))
             internal_storage.put_data(status_key, dmpd_response_status)

--- a/pywren_ibm_cloud/action/handler.py
+++ b/pywren_ibm_cloud/action/handler.py
@@ -14,22 +14,25 @@
 # limitations under the License.
 #
 
-import json
-import logging
 import os
-import subprocess
+import sys
 import time
-import traceback
 import pika
+import json
+import pickle
+import logging
+import subprocess
 import multiprocessing
+from distutils.util import strtobool
 from pywren_ibm_cloud import version
 from pywren_ibm_cloud import wrenconfig
 from pywren_ibm_cloud import wrenlogging
 from pywren_ibm_cloud.storage import storage
 from pywren_ibm_cloud.utils import sizeof_fmt
 from pywren_ibm_cloud.action.jobrunner import jobrunner
+from pywren_ibm_cloud.libs.tblib import pickling_support
 
-
+pickling_support.install()
 logging.getLogger('pika').setLevel(logging.CRITICAL)
 logger = logging.getLogger('handler')
 
@@ -63,10 +66,11 @@ def get_server_info():
     return server_info
 
 
-def ibm_cloud_function_handler(event):
+def function_handler(event):
     start_time = time.time()
-    logger.info("Action handler started")
-    response_status = {'exception': None}
+    logger.debug("Action handler started")
+    response_status = {'exception': False}
+    response_status['host_submit_time'] = event['host_submit_time']
     response_status['start_time'] = start_time
 
     context_dict = {
@@ -158,13 +162,15 @@ def ibm_cloud_function_handler(event):
         if os.path.exists(JOBRUNNER_STATS_FILENAME):
             with open(JOBRUNNER_STATS_FILENAME, 'r') as fid:
                 for l in fid.readlines():
-                    key, value = l.strip().split(" ")
+                    key, value = l.strip().split(" ", 1)
                     try:
                         response_status[key] = float(value)
                     except Exception:
                         response_status[key] = value
+                    if key == 'exception' or key == 'exc_pickle_fail' \
+                       or key == 'result':
+                        response_status[key] = eval(value)
 
-        response_status['host_submit_time'] = event['host_submit_time']
         # response_status['server_info'] = get_server_info()
         response_status.update(context_dict)
         response_status['end_time'] = time.time()
@@ -173,13 +179,16 @@ def ibm_cloud_function_handler(event):
         # internal runtime exceptions
         logger.error("There was an exception: {}".format(str(e)))
         response_status['end_time'] = time.time()
-        response_status['exception'] = str(e)
-        response_status['exception_args'] = e.args
-        response_status['exception_traceback'] = traceback.format_exc()
+        response_status['exception'] = True
+
+        pickled_exc = pickle.dumps(sys.exc_info())
+        pickle.loads(pickled_exc)  # this is just to make sure they can be unpickled
+        response_status['exc_info'] = str(pickled_exc)
 
     finally:
+        store_status = strtobool(os.environ.get('STORE_STATUS', 'True'))
         rabbit_amqp_url = config['rabbitmq'].get('amqp_url')
-        if rabbit_amqp_url:
+        if rabbit_amqp_url and store_status:
             status = 'ok'
             if response_status['exception']:
                 status = 'error'
@@ -202,13 +211,8 @@ def ibm_cloud_function_handler(event):
                 except Exception:
                     logger.error("Unable to send status to rabbitmq")
 
-        store_status = True
-        if 'STORE_STATUS' in extra_env:
-            store_status = eval(extra_env['STORE_STATUS'])
-
         if store_status:
-            print(response_status)
             internal_storage = storage.InternalStorage(storage_config)
             response_status = json.dumps(response_status)
-            logger.info("Storing function execution stats in: status.json - Size: {}".format(sizeof_fmt(len(response_status))))
+            logger.info("Storing execution stats - status.json - Size: {}".format(sizeof_fmt(len(response_status))))
             internal_storage.put_data(status_key, response_status)

--- a/pywren_ibm_cloud/future.py
+++ b/pywren_ibm_cloud/future.py
@@ -75,7 +75,6 @@ class ResponseFuture:
         self.storage_path = storage_utils.get_storage_path(self.storage_config)
 
     def _set_state(self, new_state):
-        # FIXME add state machine
         self._state = new_state
 
     def cancel(self):

--- a/pywren_ibm_cloud/libs/ibm_cf/cf_connector.py
+++ b/pywren_ibm_cloud/libs/ibm_cf/cf_connector.py
@@ -48,7 +48,8 @@ class CloudFunctions:
 
         elif 'api_key' in config['ibm_iam']:
             self.iam_connector = IAM(config['ibm_iam'], self.endpoint, self.namespace)
-            auth = self.iam_connector.get_iam_token()
+            auth_token = self.iam_connector.get_iam_token()
+            auth = 'Bearer ' + auth_token
             self.namespace_id = self.iam_connector.get_function_namespace_id(auth)
             self.effective_namespace = self.namespace_id
 
@@ -165,7 +166,7 @@ class CloudFunctions:
         """
         Delete an IBM Cloud Functions package
         """
-        logger.debug("I am about to delete a cloud function package: {}".format(package))
+        logger.debug("I am about to delete the package: {}".format(package))
         url = '/'.join([self.endpoint, 'api', 'v1', 'namespaces', self.effective_namespace, 'packages', package])
         res = self.session.delete(url)
         resp_text = res.json()
@@ -179,7 +180,7 @@ class CloudFunctions:
         """
         Create an IBM Cloud Functions package
         """
-        logger.debug('I am about to crate the package {}'.format(package))
+        logger.debug('I am about to create the package {}'.format(package))
         url = '/'.join([self.endpoint, 'api', 'v1', 'namespaces', self.effective_namespace, 'packages', package + "?overwrite=False"])
 
         data = {"name": package}

--- a/pywren_ibm_cloud/libs/ibm_iam/iam_connector.py
+++ b/pywren_ibm_cloud/libs/ibm_iam/iam_connector.py
@@ -42,7 +42,7 @@ class IAM:
             raise RuntimeError("Error: http code {} while retrieving IAM token for API key.".format(res.status_code))
 
         bearer_response = res.json()
-        bearer_token = 'Bearer ' + bearer_response['access_token']
+        bearer_token = bearer_response['access_token']
         logger.debug(bearer_token)
 
         return bearer_token

--- a/pywren_ibm_cloud/libs/tblib/__init__.py
+++ b/pywren_ibm_cloud/libs/tblib/__init__.py
@@ -15,7 +15,7 @@ except ImportError:
 if not tb_set_next and not tproxy:
     raise ImportError("Cannot use tblib. Runtime not supported.")
 
-__version__ = '1.3.2'
+__version__ = '1.4.0'
 __all__ = 'Traceback',
 
 PY3 = sys.version_info[0] == 3
@@ -37,6 +37,9 @@ class TracebackParseError(Exception):
 
 
 class Code(object):
+
+    co_code = None
+
     def __init__(self, code):
         self.co_filename = code.co_filename
         self.co_name = code.co_name
@@ -44,11 +47,11 @@ class Code(object):
 
 class Frame(object):
     def __init__(self, frame):
-        self.f_globals = dict([
-            (k, v)
+        self.f_globals = {
+            k: v
             for k, v in frame.f_globals.items()
             if k in ("__file__", "__name__")
-        ])
+        }
         self.f_code = Code(frame.f_code)
 
     def clear(self):
@@ -112,7 +115,7 @@ class Traceback(object):
             # noinspection PyBroadException
             try:
                 exec(code, current.tb_frame.f_globals, {})
-            except:
+            except Exception:
                 next_tb = sys.exc_info()[2].tb_next
                 if top_tb is None:
                     top_tb = next_tb

--- a/pywren_ibm_cloud/wait.py
+++ b/pywren_ibm_cloud/wait.py
@@ -275,7 +275,7 @@ def _wait_storage(fs, executor_id, internal_storage, download_results,
     f_to_wait_on = []
     for f in fs:
         if (download_results and f.done) or \
-           (not download_results and f.ready) or \
+           (not download_results and (f.ready or f.done)) or \
            (download_results and f.ready and not f._produce_output):
             # done, don't need to do anything
             fs_dones.append(f)
@@ -314,7 +314,7 @@ def _wait_storage(fs, executor_id, internal_storage, download_results,
     if pbar:
         for f in f_to_wait_on:
             if (download_results and f.done) or \
-               (not download_results and f.ready) or \
+               (not download_results and (f.ready or f.done)) or \
                (download_results and f.ready and not f._produce_output):
                 pbar.update(1)
         pbar.refresh()

--- a/pywren_ibm_cloud/wait.py
+++ b/pywren_ibm_cloud/wait.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import json
 import time
 import pika
 import queue
@@ -21,6 +22,7 @@ import random
 import logging
 import threading
 from multiprocessing.pool import ThreadPool
+from .future import JobState
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,7 @@ def wait(fs, executor_id, internal_storage, download_results=False,
 
         if rabbit_amqp_url and not download_results:
             callgroup_id = fs[0].callgroup_id
-            return _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, N)
+            return _wait_rabbitmq(fs, executor_id, callgroup_id, rabbit_amqp_url, pbar, N)
 
         result_count = 0
 
@@ -146,15 +148,35 @@ class rabbitmq_checker_worker(threading.Thread):
         logger.debug(msg)
         self.channel.start_consuming()
 
+    def __del__(self):
+        self.channel.queue_delete(queue=self.executor_id)
+        self.channel.stop_consuming()
 
-def _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, total):
+
+def _wait_rabbitmq(fs, executor_id, callgroup_id, rabbit_amqp_url, pbar, total):
     q = queue.Queue()
     td = rabbitmq_checker_worker(executor_id, rabbit_amqp_url, q)
     td.setDaemon(True)
     td.start()
 
+    done_call_status = {}
+    done_call_status[callgroup_id] = {}
     done_call_ids = {}
     done_call_ids[callgroup_id] = {'total': total, 'call_ids': []}
+
+    def call_ids_to_futures():
+        fs_dones = []
+        fs_notdones = []
+        for f in fs:
+            if f.callgroup_id in done_call_status and f.call_id in done_call_status[f.callgroup_id]:
+                f.run_status = done_call_status[f.callgroup_id][f.call_id]
+                f.invoke_status['status_done_timestamp'] = f.run_status['status_done_timestamp']
+                del f.run_status['status_done_timestamp']
+                f._set_state(JobState.ready)
+                fs_dones.append(f)
+            else:
+                fs_notdones.append(f)
+        return fs_dones, fs_notdones
 
     def reception_finished():
         for cg_id in done_call_ids:
@@ -167,34 +189,46 @@ def _wait_rabbitmq(executor_id, callgroup_id, rabbit_amqp_url, pbar, total):
         return True
 
     while not reception_finished():
-        data = q.get().split(':')
-        rcv_callgroup_id, rcv_call_id = data[0].split('/')
+        try:
+            call_status = json.loads(q.get())
+            call_status['status_done_timestamp'] = time.time()
+        except KeyboardInterrupt:
+            call_ids_to_futures()
+            raise KeyboardInterrupt
+
+        rcv_callgroup_id = call_status['callgroup_id']
+        rcv_call_id = call_status['call_id']
+
         if rcv_callgroup_id not in done_call_ids:
             done_call_ids[rcv_callgroup_id] = {'total': None, 'call_ids': []}
+        if rcv_callgroup_id not in done_call_status:
+            done_call_status[callgroup_id] = {}
+
         done_call_ids[rcv_callgroup_id]['call_ids'].append(rcv_call_id)
+        done_call_status[rcv_callgroup_id][rcv_call_id] = call_status
 
         if pbar:
             pbar.update(1)
             pbar.refresh()
 
-        new_futures = data[-1].split('/')
-        if int(new_futures[1]) != 0:
-            # We received new futures to track
-            callgroup_id_new_futures = new_futures[0]
-            total_new_futures = int(new_futures[1])
-            if callgroup_id_new_futures not in done_call_ids:
-                done_call_ids[callgroup_id_new_futures] = {'total': total_new_futures, 'call_ids': []}
-            else:
-                done_call_ids[callgroup_id_new_futures]['total'] = total_new_futures
+        if 'new_futures' in call_status:
+            new_futures = call_status['new_futures'].split('/')
+            if int(new_futures[1]) != 0:
+                # We received new futures to track
+                callgroup_id_new_futures = new_futures[0]
+                total_new_futures = int(new_futures[1])
+                if callgroup_id_new_futures not in done_call_ids:
+                    done_call_ids[callgroup_id_new_futures] = {'total': total_new_futures, 'call_ids': []}
+                else:
+                    done_call_ids[callgroup_id_new_futures]['total'] = total_new_futures
 
-            if pbar:
-                pbar.total = pbar.total + total_new_futures
-                pbar.refresh()
-
+                if pbar:
+                    pbar.total = pbar.total + total_new_futures
+                    pbar.refresh()
     if pbar:
         pbar.close()
 
-    return None, None
+    return call_ids_to_futures()
 
 
 def _wait_storage(fs, executor_id, internal_storage, download_results,

--- a/pywren_ibm_cloud/wren.py
+++ b/pywren_ibm_cloud/wren.py
@@ -410,10 +410,7 @@ class ibm_cf_executor:
         result = [f.result() for f in fs_dones if f.done and not f.futures]
         self.futures = []
         msg = "Executor ID {} Finished getting results".format(self.executor_id)
-        logger.info(msg)
-        if not self.log_level:
-            print(msg)
-
+        logger.debug(msg)
         if result and len(result) == 1:
             return result[0]
         return result

--- a/pywren_ibm_cloud/wren.py
+++ b/pywren_ibm_cloud/wren.py
@@ -22,7 +22,6 @@ import json
 import signal
 import logging
 import traceback
-from six import reraise
 from pywren_ibm_cloud import invokers
 from pywren_ibm_cloud import wrenconfig
 from pywren_ibm_cloud import wrenlogging
@@ -436,11 +435,7 @@ class ibm_cf_executor:
         else:
             ftrs = futures
 
-        if self.rabbitmq_monitor:
-            ftrs_to_plot = ftrs
-            self.monitor(futures=ftrs_to_plot)
-        else:
-            ftrs_to_plot = [f for f in ftrs if f.ready or f.done]
+        ftrs_to_plot = [f for f in ftrs if f.ready or f.done]
 
         if not ftrs_to_plot:
             return
@@ -457,10 +452,6 @@ class ibm_cf_executor:
 
         run_statuses = [f.run_status for f in ftrs_to_plot]
         invoke_statuses = [f.invoke_status for f in ftrs_to_plot]
-
-        if self.rabbitmq_monitor and invoke_statuses:
-            for in_stat in invoke_statuses:
-                del in_stat['status_done_timestamp']
 
         create_timeline(dst_dir, dst_file_name, self.start_time, run_statuses, invoke_statuses, self.config['ibm_cos'])
         create_histogram(dst_dir, dst_file_name, self.start_time, run_statuses, self.config['ibm_cos'])


### PR DESCRIPTION
1. In this patch I improved the exception management when a function produces an exception so that PyWren only prints the exception traceback of the function, instead of the full traceback from the local pywren code. For example, currently when an exception is produced within a function, pywren shows all of this traceback:
```
Traceback (most recent call last):
  File "examples/rabbitmq_monitor.py", line 51, in <module>
    results = pw.get_result()
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/wren.py", line 387, in get_result
    WAIT_DUR_SEC=WAIT_DUR_SEC)
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/wren.py", line 323, in monitor
    pbar=pbar, THREADPOOL_SIZE=THREADPOOL_SIZE, WAIT_DUR_SEC=WAIT_DUR_SEC)
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/wait.py", line 83, in wait
    pbar=pbar)
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/wait.py", line 310, in _wait_storage
    pool.map(get_result, f_to_wait_on)
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 288, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 670, in get
    raise self._value
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/wait.py", line 294, in get_result
    f.result(throw_except=throw_except, internal_storage=internal_storage)
  File "/home/josep/data/eclipse-workspace/pywren-ibm-cloud/pywren_ibm_cloud/future.py", line 295, in result
    reraise(*self._traceback)
  File "/usr/lib/python3/dist-packages/six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "/action/pywren_ibm_cloud/action/jobrunner.py", line 206, in run
  File "examples/rabbitmq_monitor.py", line 34, in my_function
    print(data['key'])
KeyError: 'key'
```
95% of this traceback is completely unnecessary for the users, since it shows from where the "function traceback" is reraised from the internal pywren code.

Now Pywren shows the activation ID that produced the exception, and only the traceback from the function:
```
Executor ID 8fc42196-1e46 There was an exception - Activation ID: f4c654118d514e8d8654118d515e8df3

Traceback (most recent call last):
  File "/action/pywren_ibm_cloud/action/jobrunner.py", line 203, in run
  File "examples/rabbitmq_monitor.py", line 34, in my_function
    print(data['key'])
KeyError: 'key'
```


2. Also modified the pywren remote code so that when a user doesn't put the return statement in the function (i.e, the function doesn't produce a result), then the output.pickle file is not stored in COS, preventing thus thousands of unnecessary connections against COS.

3. Improved status management when rabbitmq is activated.
 



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

