### PR TITLE
Add function_name to future's status

### DIFF
--- a/pywren_ibm_cloud/action/handler.py
+++ b/pywren_ibm_cloud/action/handler.py
@@ -82,10 +82,12 @@ def function_handler(event):
     log_level = event['log_level']
     wrenlogging.ow_config(log_level)
 
+    func_name = event['function_name']
     call_id = event['call_id']
     callgroup_id = event['callgroup_id']
     executor_id = event['executor_id']
     logger.info("Execution ID: {}/{}/{}".format(executor_id, callgroup_id, call_id))
+    runtime_memory = config['pywren']['runtime_memory']
     job_max_runtime = event.get("job_max_runtime", 590)  # default for CF
     status_key = event['status_key']
     func_key = event['func_key']
@@ -94,9 +96,11 @@ def function_handler(event):
     output_key = event['output_key']
     extra_env = event.get('extra_env', {})
 
+    response_status['function_name'] = func_name
     response_status['call_id'] = call_id
     response_status['callgroup_id'] = callgroup_id
     response_status['executor_id'] = executor_id
+    response_status['runtime_memory'] = runtime_memory
     # response_status['func_key'] = func_key
     # response_status['data_key'] = data_key
     # response_status['output_key'] = output_key

--- a/pywren_ibm_cloud/action/handler.py
+++ b/pywren_ibm_cloud/action/handler.py
@@ -82,12 +82,10 @@ def function_handler(event):
     log_level = event['log_level']
     wrenlogging.ow_config(log_level)
 
-    func_name = event['function_name']
     call_id = event['call_id']
     callgroup_id = event['callgroup_id']
     executor_id = event['executor_id']
     logger.info("Execution ID: {}/{}/{}".format(executor_id, callgroup_id, call_id))
-    runtime_memory = config['pywren']['runtime_memory']
     job_max_runtime = event.get("job_max_runtime", 590)  # default for CF
     status_key = event['status_key']
     func_key = event['func_key']
@@ -96,11 +94,9 @@ def function_handler(event):
     output_key = event['output_key']
     extra_env = event.get('extra_env', {})
 
-    response_status['function_name'] = func_name
     response_status['call_id'] = call_id
     response_status['callgroup_id'] = callgroup_id
     response_status['executor_id'] = executor_id
-    response_status['runtime_memory'] = runtime_memory
     # response_status['func_key'] = func_key
     # response_status['data_key'] = data_key
     # response_status['output_key'] = output_key

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -69,7 +69,7 @@ class Executor(object):
 
     def invoke_with_keys(self, func_key, data_key, output_key,
                          status_key, executor_id, callgroup_id,
-                         call_id, func_name, extra_env,
+                         call_id, extra_env,
                          extra_meta, data_byte_range,
                          host_job_meta, job_max_runtime,
                          overwrite_invoke_args=None):
@@ -88,7 +88,6 @@ class Executor(object):
             'executor_id': executor_id,
             'callgroup_id': callgroup_id,
             'call_id': call_id,
-            'function_name': func_name,
             'pywren_version': version.__version__}
 
         if extra_env is not None:
@@ -295,6 +294,7 @@ class Executor(object):
 
         module_data = create_mod_data(mod_paths)
         # Create func and upload
+        host_job_meta['func_name'] = func_name
         func_module_str = pickle.dumps({'func': func_str, 'module_data': module_data}, -1)
         host_job_meta['func_module_bytes'] = len(func_module_str)
 
@@ -329,7 +329,7 @@ class Executor(object):
             return self.invoke_with_keys(func_key, data_key,
                                          output_key, status_key,
                                          executor_id, callgroup_id,
-                                         call_id, func_name, extra_env,
+                                         call_id, extra_env,
                                          extra_meta, data_byte_range,
                                          host_job_meta.copy(),
                                          job_max_runtime,

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -69,7 +69,7 @@ class Executor(object):
 
     def invoke_with_keys(self, func_key, data_key, output_key,
                          status_key, executor_id, callgroup_id,
-                         call_id, extra_env,
+                         call_id, func_name, extra_env,
                          extra_meta, data_byte_range,
                          host_job_meta, job_max_runtime,
                          overwrite_invoke_args=None):
@@ -88,6 +88,7 @@ class Executor(object):
             'executor_id': executor_id,
             'callgroup_id': callgroup_id,
             'call_id': call_id,
+            'function_name': func_name,
             'pywren_version': version.__version__}
 
         if extra_env is not None:
@@ -328,7 +329,7 @@ class Executor(object):
             return self.invoke_with_keys(func_key, data_key,
                                          output_key, status_key,
                                          executor_id, callgroup_id,
-                                         call_id, extra_env,
+                                         call_id, func_name, extra_env,
                                          extra_meta, data_byte_range,
                                          host_job_meta.copy(),
                                          job_max_runtime,


### PR DESCRIPTION
with this minor change we can know from which function the future came from and its runtime memory.
I found it useful for diagnosing PyWren results.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
