### PR TITLE
Integrated CloudObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ You can use IBM-PyWren inside an **IBM Watson Studio** or Jupyter notebooks in o
 As the current **IBM Watson Studio** runtimes does not contains the **PyWren** package, it is needed to install it. Add these lines at the beginning of the notebook:
 
 ```python
+import sys
 try:
     import pywren_ibm_cloud as pywren
 except:
@@ -369,10 +370,10 @@ except:
 ```
 Installation supports PyWren version as an input parameter, for example:
 
-	!{sys.executable} -m pip install -U pywren-ibm-cloud==1.0.7
+	!{sys.executable} -m pip install -U pywren-ibm-cloud==1.0.15
 
 ### Usage in notebooks
-Once installed, you can use IBM-PyWren as usual inside a notebook:
+Once installed, you can use IBM-PyWren as usual inside a notebook. Don't forget of the [configuration](#configuration):
 
 ```python
 import pywren_ibm_cloud as pywren

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -1,0 +1,26 @@
+"""
+Simple PyWren example using cloudobjects to transparently pass
+objects stored in the storage backend between functions without
+knowing they reference
+"""
+import pywren_ibm_cloud as pywren
+
+
+def my_function_put(text, internal_storage):
+    co1 = internal_storage.put_object('Temp object test 1: {}'.format(text, ))
+    co2 = internal_storage.put_object('Temp object test 2: {}'.format(text, ))
+    return [co1, co2]
+
+
+def my_function_get(co, internal_storage):
+    data = internal_storage.get_object(co)
+    return data
+
+
+if __name__ == "__main__":
+    pw = pywren.ibm_cf_executor()
+    pw.call_async(my_function_put, 'Hello World')
+    cloudobjects = pw.get_result()
+    pw.map(my_function_get, cloudobjects)
+    print(pw.get_result())
+    pw.clean()

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -1,7 +1,7 @@
 """
 Simple PyWren example using cloudobjects to transparently pass
 objects stored in the storage backend between functions without
-knowing they reference
+knowing they exact location (bucket, key)
 """
 import pywren_ibm_cloud as pywren
 
@@ -23,4 +23,5 @@ if __name__ == "__main__":
     cloudobjects = pw.get_result()
     pw.map(my_function_get, cloudobjects)
     print(pw.get_result())
+    pw.create_timeline_plots('/home/josep/pywren_plots', 'no_rabbitmq')
     pw.clean()

--- a/pywren_ibm_cloud/__init__.py
+++ b/pywren_ibm_cloud/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from pywren_ibm_cloud.executor import ibm_cf_executor
+from pywren_ibm_cloud.executor import ServerlessExecutor as ibm_cf_executor
 from pywren_ibm_cloud.version import __version__
 
 name = "pywren_ibm_cloud"

--- a/pywren_ibm_cloud/__init__.py
+++ b/pywren_ibm_cloud/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from pywren_ibm_cloud.executor import ServerlessExecutor as ibm_cf_executor
+from pywren_ibm_cloud.executor import FunctionExecutor as ibm_cf_executor
 from pywren_ibm_cloud.version import __version__
 
 name = "pywren_ibm_cloud"

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -28,7 +28,7 @@ class ExecutorState(enum.Enum):
     finished = 6
 
 
-class ibm_cf_executor:
+class ServerlessExecutor:
 
     def __init__(self, config=None, runtime=None, runtime_memory=None, log_level=None, rabbitmq_monitor=False):
         """
@@ -40,10 +40,6 @@ class ibm_cf_executor:
         :param log_level: log level to use during the execution
         :param rabbitmq_monitor: use rabbitmq as monitoring system
         :return `ServerlessExecutor` object.
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
         """
         self.start_time = time.time()
         self._state = ExecutorState.new
@@ -67,8 +63,8 @@ class ibm_cf_executor:
             if not self.is_cf_cluster:
                 default_logging_config(self.log_level)
 
-        if 'PYWREN_EXECUTOR_ID' in os.environ:
-            self.executor_id = os.environ['PYWREN_EXECUTOR_ID']
+        if 'CB_EXECUTOR_ID' in os.environ:
+            self.executor_id = os.environ['CB_EXECUTOR_ID']
         else:
             self.executor_id = create_executor_id()
         logger.debug('ServerlessExecutor created with ID: {}'.format(self.executor_id))
@@ -97,11 +93,6 @@ class ibm_cf_executor:
         :param data: input data
         :param extra_env: Additional environment variables for action environment. Default None.
         :param extra_meta: Additional metadata to pass to action. Default None.
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
-          >>> future = pw.call_async(foo, data)
         """
 
         if self._state == ExecutorState.finished:
@@ -135,11 +126,6 @@ class ibm_cf_executor:
         :param exclude_modules: Explicitly keep these modules from pickled dependencies.
         :return: A list with size `len(iterdata)` of futures for each job
         :rtype: list of futures.
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
-          >>> futures = pw.map(foo, data_list)
         """
         if self._state == ExecutorState.finished:
             raise Exception('You cannot run map() in the current state.'

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -28,7 +28,7 @@ class ExecutorState(enum.Enum):
     finished = 6
 
 
-class ServerlessExecutor:
+class FunctionExecutor:
 
     def __init__(self, config=None, runtime=None, runtime_memory=None, log_level=None, rabbitmq_monitor=False):
         """
@@ -176,11 +176,6 @@ class ServerlessExecutor:
         :param overwrite_invoke_args: Overwrite other args. Mainly used for testing.
         :param exclude_modules: Explicitly keep these modules from pickled dependencies.
         :return: A list with size `len(map_iterdata)` of futures for each job
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
-          >>> pw.map_reduce(foo, map_data_list, bar)
         """
 
         if self._state == ExecutorState.finished:
@@ -234,15 +229,7 @@ class ServerlessExecutor:
         :return: `(fs_done, fs_notdone)`
             where `fs_done` is a list of futures that have completed
             and `fs_notdone` is a list of futures that have not completed.
-        :rtype: 2-tuple of lists
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
-          >>> pw.map(foo, data_list)
-          >>> dones, not_dones = pw.monitor()
-          >>> # not_dones should be an empty list.
-          >>> results = [f.result() for f in dones]
+        :rtype: 2-tuple of list
         """
         if futures:
             # Ensure futures is a list
@@ -361,12 +348,6 @@ class ServerlessExecutor:
         :param THREADPOOL_SIZE: Number of threads to use. Default 64
         :param WAIT_DUR_SEC: Time interval between each check.
         :return: The result of the future/s
-
-        Usage
-          >>> import pywren_ibm_cloud as pywren
-          >>> pw = pywren.ibm_cf_executor()
-          >>> pw.map(foo, data)
-          >>> results = pw.get_result()
         """
         fs_dones, unused_fs_notdones = self.monitor(futures=futures, throw_except=throw_except,
                                                     timeout=timeout, download_results=True,
@@ -397,10 +378,12 @@ class ServerlessExecutor:
                             ' before calling create_timeline_plots() method')
 
         if not futures:
+            futures = []
             if self.futures:
-                futures = self.futures
-            elif self.executor_futures:
-                futures = self.executor_futures[-1]
+                futures.extend(self.futures)
+            if self.executor_futures:
+                for pre_fut in self.executor_futures:
+                    futures.extend(pre_fut)
 
         if type(futures) != list:
             ftrs = [futures]

--- a/pywren_ibm_cloud/job/job.py
+++ b/pywren_ibm_cloud/job/job.py
@@ -124,6 +124,8 @@ def create_reduce_job(config, internal_storage, executor_id, reduce_function, re
         func_sig = inspect.signature(reduce_function)
         if 'ibm_cos' in func_sig.parameters:
             reduce_func_args['ibm_cos'] = ibm_cos
+        if 'internal_storage' in func_sig.parameters:
+            reduce_func_args['internal_storage'] = internal_storage
 
         return reduce_function(**reduce_func_args)
 

--- a/pywren_ibm_cloud/job/partitioner.py
+++ b/pywren_ibm_cloud/job/partitioner.py
@@ -54,7 +54,7 @@ def partition_processor(map_function):
                 bucket = map_func_args['bucket']
                 key = map_func_args['key']
 
-            config = json.loads(os.environ.get('PYWREN_CONFIG'))
+            config = json.loads(os.environ.get('CB_CONFIG'))
             storage = IbmCosStorageBackend(config['ibm_cos'])
             logger.info('Getting dataset from cos://{}/{}'.format(bucket, key))
             sb = storage.get_object(bucket, key, stream=True, extra_get_args=extra_get_args)

--- a/pywren_ibm_cloud/runtime/function_handler/handler.py
+++ b/pywren_ibm_cloud/runtime/function_handler/handler.py
@@ -109,8 +109,8 @@ def function_handler(event):
 
         # response_status['free_disk_bytes'] = free_disk_space("/tmp")
 
-        custom_env = {'PYWREN_CONFIG': json.dumps(config),
-                      'PYWREN_EXECUTOR_ID':  executor_id,
+        custom_env = {'CB_CONFIG': json.dumps(config),
+                      'CB_EXECUTOR_ID':  executor_id,
                       'PYTHONPATH': "{}:{}".format(os.getcwd(), PYWREN_LIBS_PATH),
                       'PYTHONUNBUFFERED': 'True'}
 

--- a/pywren_ibm_cloud/runtime/function_handler/jobrunner.py
+++ b/pywren_ibm_cloud/runtime/function_handler/jobrunner.py
@@ -64,8 +64,8 @@ class jobrunner(Process):
         cloud_logging_config(log_level)
         self.stats = stats(self.config['stats_filename'])
         self.stats.write('jobrunner_start', start_time)
-        pw_config = json.loads(os.environ.get('PYWREN_CONFIG'))
-        self.storage_config = extract_storage_config(pw_config)
+        cb_config = json.loads(os.environ.get('CB_CONFIG'))
+        self.storage_config = extract_storage_config(cb_config)
 
         if 'SHOW_MEMORY_USAGE' in os.environ:
             self.show_memory = eval(os.environ['SHOW_MEMORY_USAGE'])

--- a/pywren_ibm_cloud/runtime/function_handler/jobrunner.py
+++ b/pywren_ibm_cloud/runtime/function_handler/jobrunner.py
@@ -179,7 +179,7 @@ class jobrunner(Process):
         exception = False
         try:
             self.internal_storage = InternalStorage(self.storage_config)
-
+            self.internal_storage.tmp_obj_prefix = self.output_key.rsplit('/', 1)[0]
             loaded_func_all = self._get_function_and_modules()
             self._save_modules(loaded_func_all['module_data'])
             function = self._unpickle_function(loaded_func_all['func'])

--- a/pywren_ibm_cloud/storage/internal_storage.py
+++ b/pywren_ibm_cloud/storage/internal_storage.py
@@ -101,6 +101,7 @@ class InternalStorage:
             body = self.storage_handler.get_object(bucket, key)
             return pickle.loads(body)
         else:
+            logger.debug("Invalid Compute backend")
             return None
 
     def get_callset_status(self, executor_id):

--- a/pywren_ibm_cloud/storage/internal_storage.py
+++ b/pywren_ibm_cloud/storage/internal_storage.py
@@ -105,8 +105,7 @@ class InternalStorage:
             body = self.storage_handler.get_object(bucket, key)
             return pickle.loads(body)
         else:
-            logger.debug("Invalid Compute backend")
-            return None
+            raise Exception("CloudObject: Invalid Storage backend for retrieving the object")
 
     def get_callset_status(self, executor_id):
         """

--- a/pywren_ibm_cloud/storage/storage_utils.py
+++ b/pywren_ibm_cloud/storage/storage_utils.py
@@ -108,3 +108,10 @@ def check_storage_path(config, prev_path):
     current_path = get_storage_path(config)
     if current_path != prev_path:
         raise StorageConfigMismatchError(current_path, prev_path)
+
+
+class CloudObject:
+    def __init__(self, storage_backend, bucket, key):
+        self.storage_type = storage_backend
+        self.key = key
+        self.bucket = bucket

--- a/pywren_ibm_cloud/storage/storage_utils.py
+++ b/pywren_ibm_cloud/storage/storage_utils.py
@@ -112,6 +112,6 @@ def check_storage_path(config, prev_path):
 
 class CloudObject:
     def __init__(self, storage_backend, bucket, key):
-        self.storage_type = storage_backend
+        self.storage_backend = storage_backend
         self.key = key
         self.bucket = bucket


### PR DESCRIPTION
This patch integrates the CloudObject class. 

To operate with CloudObjects, it adds 2 methods in internal_storage class  in order to put temporary data from a function and get this data from another function in a transparent way.

Writing **internal_storage** as a parameter of the function automatically creates an instance of it, allowing to execute the new `internal_storage.put_object()` and` internal_storage.get_object()` methods. The `put_object()` method returns a CloudObject instance.

Example:

```
import pywren_ibm_cloud as pywren

def my_function_put(text, internal_storage):
    co1 = internal_storage.put_object('Temp object test 1: {}'.format(text, ))
    co2 = internal_storage.put_object('Temp object test 2: {}'.format(text, ))

    return [co1, co2]

def my_function_get(co, internal_storage):
    data = internal_storage.get_object(co)

    return data

pw = pywren.ibm_cf_executor()
pw.call_async(my_function_put, 'Hello World')
cloudobjects = pw.get_result()
pw.map(my_function_get, cloudobjects)
print(pw.get_result())
pw.clean()
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

