### PR TITLE
add new docker image for satellite imagery

### DIFF
--- a/runtime/ibm_cf/Dockerfile.gdal.conda
+++ b/runtime/ibm_cf/Dockerfile.gdal.conda
@@ -1,0 +1,9 @@
+# GDAL layers
+FROM continuumio/miniconda3
+RUN conda install gdal
+
+# pyrip layers
+RUN pip install pyrip
+
+# Application layers
+RUN pip install ibm-cos-sdk pyarrow


### PR DESCRIPTION
Add a new docker image into runtime, for support of processing satellite imagery pipeline with Cloud Function + Pywren.