### PR TITLE
Setting 10 minutes timeout to the webserver

### DIFF
--- a/runtime/knative/Dockerfile
+++ b/runtime/knative/Dockerfile
@@ -29,4 +29,4 @@ WORKDIR $APP_HOME
 COPY pywren_knative.zip .
 RUN unzip pywren_knative.zip && rm pywren_knative.zip
 
-CMD exec gunicorn --bind :$PORT --workers 1 pywrenproxy:proxy
+CMD exec gunicorn --bind :$PORT --workers 1 --timeout 600 pywrenproxy:proxy


### PR DESCRIPTION
Currently long running actions fail on knative due to short gunicorn timeout. This PR resolves it by setting timeout same as in HTTP request:

https://github.com/pywren/pywren-ibm-cloud/blob/master/pywren_ibm_cloud/compute/backends/knative/knative.py#L523
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

