### PR TITLE
Improved cloudobjects management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 ### Added
 - Added 'data_limit' config param in pywren section
+- Added context manager like executor and example
 
 ### Changed
 - Reducer logic moved to jobrunner
 - Set default Knative runtime timeout to 10 minutes
 - Added more debug logs in Knative
 - Enabled building default knative runtime locally
+- cloudobject methods moved from internal_storage to ibm_cos
+- renamed cloudobject put method from 'put_object' to 'put_cobject'
+- renamed cloudobject get method from 'get_object' to 'get_cobject'
+- 'internal_storage' func param reamed to 'storage'
+- pw.clean method can now clean cloudobjects
 
 ### Fixed
 - Fixed issue in map_reduce() method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added 'data_limit' config param in pywren section
-- Added context manager like executor and example
+- Added context-manager-like executor and example
 
 ### Changed
 - Reducer logic moved to jobrunner
@@ -14,7 +14,7 @@
 - cloudobject methods moved from internal_storage to ibm_cos
 - renamed cloudobject put method from 'put_object' to 'put_cobject'
 - renamed cloudobject get method from 'get_object' to 'get_cobject'
-- 'internal_storage' func param reamed to 'storage'
+- 'internal_storage' func param renamed to 'storage'
 - pw.clean method can now clean cloudobjects
 
 ### Fixed

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -23,4 +23,3 @@ if __name__ == "__main__":
     cloudobjects = pw.get_result()
     pw.map(my_function_get, cloudobjects)
     print(pw.get_result())
-    pw.clean()

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -18,8 +18,31 @@ def my_function_get(co, ibm_cos):
 
 
 if __name__ == "__main__":
+    """
+    Managing cloudobjects with context manager.
+    At the end of the with statement all
+    cloudobjects are automatically deleted.
+    """
     with pywren.ibm_cf_executor() as pw:
-        pw.call_async(my_function_put, 'Hello World')
+        pw.call_async(my_function_put, 'Hello Earth')
         cloudobjects = pw.get_result()
         pw.map(my_function_get, cloudobjects)
         print(pw.get_result())
+
+    """
+    Managing cloudobjects without context manager.
+    pw.clean() must be called at the end to delete
+    the cloudobjects created in the same executor as
+    long as you used the default location.
+    Alternatively, you can call pw.clean(cs=cloudobjects)
+    to delete a specific list of cloudobjects.
+    pw.clean(cs=cloudobjects) is mandatory if you created
+    the cloudobjects in a custom location.
+    """
+    pw = pywren.ibm_cf_executor()
+    pw.call_async(my_function_put, 'Hello Moon')
+    cloudobjects = pw.get_result()
+    pw.map(my_function_get, cloudobjects)
+    result = pw.get_result()
+    pw.clean()  # or pw.clean(cs=cloudobjects)
+    print(result)

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -7,7 +7,7 @@ import pywren_ibm_cloud as pywren
 
 
 def my_function_put(text, ibm_cos):
-    co1 = ibm_cos.put_cobject('Cloudobject Test 1: {}'.format(text, ))
+    co1 = ibm_cos.put_cobject('Cloudobject test 1: {}'.format(text, ))
     co2 = ibm_cos.put_cobject('Cloudobject test 2: {}'.format(text, ))
     return [co1, co2]
 

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -18,8 +18,8 @@ def my_function_get(co, ibm_cos):
 
 
 if __name__ == "__main__":
-    pw = pywren.ibm_cf_executor()
-    pw.call_async(my_function_put, 'Hello World')
-    cloudobjects = pw.get_result()
-    pw.map(my_function_get, cloudobjects)
-    print(pw.get_result())
+    with pywren.ibm_cf_executor() as pw:
+        pw.call_async(my_function_put, 'Hello World')
+        cloudobjects = pw.get_result()
+        pw.map(my_function_get, cloudobjects)
+        print(pw.get_result())

--- a/examples/cloudobject.py
+++ b/examples/cloudobject.py
@@ -6,14 +6,14 @@ knowing they exact location (bucket, key)
 import pywren_ibm_cloud as pywren
 
 
-def my_function_put(text, internal_storage):
-    co1 = internal_storage.put_object('Temp object test 1: {}'.format(text, ))
-    co2 = internal_storage.put_object('Temp object test 2: {}'.format(text, ))
+def my_function_put(text, ibm_cos):
+    co1 = ibm_cos.put_cobject('Cloudobject Test 1: {}'.format(text, ))
+    co2 = ibm_cos.put_cobject('Cloudobject test 2: {}'.format(text, ))
     return [co1, co2]
 
 
-def my_function_get(co, internal_storage):
-    data = internal_storage.get_object(co)
+def my_function_get(co, ibm_cos):
+    data = ibm_cos.get_cobject(co)
     return data
 
 

--- a/examples/context_manager.py
+++ b/examples/context_manager.py
@@ -1,0 +1,20 @@
+"""
+Simple PyWren example using the map method and
+the context manager. In this example the map()
+method will launch one map function for each entry
+in 'iterdata'. Finally it will print the results
+for each invocation with pw.get_result()
+"""
+import pywren_ibm_cloud as pywren
+
+
+def my_map_function(id, x):
+    print("I'm activation number {}".format(id))
+    return x + 7
+
+
+if __name__ == "__main__":
+    iterdata = [1, 2, 3, 4]
+    with pywren.ibm_cf_executor() as pw:
+        pw.map(my_map_function, iterdata)
+        print(pw.get_result())

--- a/pywren_ibm_cloud/cli/runtime/utils.py
+++ b/pywren_ibm_cloud/cli/runtime/utils.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 #
 
-import os
 import logging
-from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, \
-    JOBS_PREFIX, default_config, extract_storage_config, extract_compute_config
 from pywren_ibm_cloud.storage import InternalStorage
 from pywren_ibm_cloud.compute import Compute
+from pywren_ibm_cloud.config import default_config, extract_storage_config, extract_compute_config
+
 
 logger = logging.getLogger(__name__)
 

--- a/pywren_ibm_cloud/cli/utils.py
+++ b/pywren_ibm_cloud/cli/utils.py
@@ -22,7 +22,7 @@ from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, \
     JOBS_PREFIX, default_config, extract_storage_config, extract_compute_config
 from pywren_ibm_cloud.storage import InternalStorage
 from pywren_ibm_cloud.compute import Compute
-from pywren_ibm_cloud.storage.utils import clean_os_bucket
+from pywren_ibm_cloud.storage.utils import clean_bucket
 
 TEMP = tempfile.gettempdir()
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ def clean_all(config=None):
     if runtimes:
         sh.delete_objects(storage_config['bucket'], runtimes)
     compute_handler.delete_all_runtimes()
-    clean_os_bucket(storage_config['bucket'], JOBS_PREFIX, internal_storage, sleep=1)
+    clean_bucket(storage_config['bucket'], JOBS_PREFIX, internal_storage, sleep=1)
 
     # Clean local runtime_meta cache
     if os.path.exists(CACHE_DIR):

--- a/pywren_ibm_cloud/config.py
+++ b/pywren_ibm_cloud/config.py
@@ -26,6 +26,7 @@ COMPUTE_BACKEND_DEFAULT = 'ibm_cf'
 STORAGE_BACKEND_DEFAULT = 'ibm_cos'
 JOBS_PREFIX = "pywren.jobs"
 LOGS_PREFIX = "pywren.logs"
+TMP_PREFIX = "pywren.tmp"
 RUNTIMES_PREFIX = "pywren.runtimes"
 MAX_AGG_DATA_SIZE = 4  # 4MiB
 

--- a/pywren_ibm_cloud/config.py
+++ b/pywren_ibm_cloud/config.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 COMPUTE_BACKEND_DEFAULT = 'ibm_cf'
 STORAGE_BACKEND_DEFAULT = 'ibm_cos'
 JOBS_PREFIX = "pywren.jobs"
+TEMP_PREFIX = "pywren.jobs/tmp"
 LOGS_PREFIX = "pywren.logs"
-TMP_PREFIX = "pywren.tmp"
 RUNTIMES_PREFIX = "pywren.runtimes"
 MAX_AGG_DATA_SIZE = 4  # 4MiB
 

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -355,7 +355,7 @@ class FunctionExecutor:
                 if not is_notebook():
                     print()
             if self.data_cleaner and not self.is_pywren_function:
-                self.clean(cloudobjects=False, force=False)
+                self.clean(cloudobjects=False, force=False, log=False)
             if not fs and error and is_notebook():
                 del self.futures[len(self.futures)-len(futures):]
 
@@ -431,7 +431,7 @@ class FunctionExecutor:
         create_timeline(ftrs_to_plot, dst)
         create_histogram(ftrs_to_plot, dst)
 
-    def clean(self, fs=None, cloudobjects=True, force=True):
+    def clean(self, fs=None, cloudobjects=True, force=True, log=True):
         """
         Deletes all the files from COS. These files include the function,
         the data serialization and the function invocation results.
@@ -458,11 +458,11 @@ class FunctionExecutor:
 
         if jobs_to_clean:
             msg = "ExecutorID {} - Cleaning temporary data".format(self.executor_id)
-            print(msg) if not self.log_level else logger.info(msg)
+            print(msg) if not self.log_level and log else logger.info(msg)
             clean_job(jobs_to_clean, self.internal_storage, clean_cloudobjects=cloudobjects)
             self.cleaned_jobs.update(jobs_to_clean)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.invoker.stop()
         if self.data_cleaner:
-            self.clean()
+            self.clean(log=False)

--- a/pywren_ibm_cloud/function/jobrunner.py
+++ b/pywren_ibm_cloud/function/jobrunner.py
@@ -32,7 +32,7 @@ from pywren_ibm_cloud.future import ResponseFuture
 from pywren_ibm_cloud.libs.tblib import pickling_support
 from pywren_ibm_cloud.utils import sizeof_fmt, b64str_to_bytes, is_object_processing_function
 from pywren_ibm_cloud.utils import WrappedStreamingBodyPartition
-from pywren_ibm_cloud.config import extract_storage_config, cloud_logging_config
+from pywren_ibm_cloud.config import cloud_logging_config
 
 pickling_support.install()
 logger = logging.getLogger('JobRunner')
@@ -65,8 +65,6 @@ class JobRunner:
         log_level = self.jr_config['log_level']
         cloud_logging_config(log_level)
         self.pywren_config = self.jr_config['pywren_config']
-        self.storage_config = extract_storage_config(self.pywren_config)
-
         self.call_id = self.jr_config['call_id']
         self.job_id = self.jr_config['job_id']
         self.executor_id = self.jr_config['executor_id']
@@ -163,15 +161,15 @@ class JobRunner:
         if 'ibm_cos' in func_sig.parameters:
             if 'ibm_cos' in self.pywren_config:
                 if self.internal_storage.backend == 'ibm_cos':
-                    ibm_boto3_client = self.internal_storage.storage_handler.get_client()
+                    ibm_boto3_client = self.internal_storage.get_client()
                 else:
                     ibm_boto3_client = Storage(self.pywren_config, 'ibm_cos').get_client()
                 data['ibm_cos'] = ibm_boto3_client
             else:
                 raise Exception('Cannot create the ibm_cos client: missing configuration')
 
-        if 'internal_storage' in func_sig.parameters:
-            data['internal_storage'] = self.internal_storage
+        if 'storage' in func_sig.parameters:
+            data['storage'] = self.internal_storage.get_client()
 
         if 'rabbitmq' in func_sig.parameters:
             if 'rabbitmq' in self.pywren_config:

--- a/pywren_ibm_cloud/job/__init__.py
+++ b/pywren_ibm_cloud/job/__init__.py
@@ -1,2 +1,3 @@
 from .job import create_map_job
 from .job import create_reduce_job
+from .job import clean_job

--- a/pywren_ibm_cloud/job/job.py
+++ b/pywren_ibm_cloud/job/job.py
@@ -207,17 +207,14 @@ def _create_job(config, internal_storage, executor_id, job_id, func, data, runti
     return job_description
 
 
-def clean_job(jobs_to_clean, internal_storage, clean_cloudobjects):
+def clean_job(jobs_to_clean, storage_config, clean_cloudobjects):
     """
     Clean the jobs in a separate process
     """
-    storage_config = internal_storage.get_storage_config()
-
     script = """
     from pywren_ibm_cloud.storage import InternalStorage
     from pywren_ibm_cloud.storage.utils import clean_bucket
     from pywren_ibm_cloud.config import JOBS_PREFIX, TEMP_PREFIX
-    import json
 
     storage_config = {}
     jobs_to_clean = {}

--- a/pywren_ibm_cloud/job/job.py
+++ b/pywren_ibm_cloud/job/job.py
@@ -207,7 +207,7 @@ def _create_job(config, internal_storage, executor_id, job_id, func, data, runti
     return job_description
 
 
-def clean_job(jobs_to_clean, internal_storage):
+def clean_job(jobs_to_clean, internal_storage, clean_cloudobjects):
     """
     Clean the jobs in a separate process
     """
@@ -216,18 +216,23 @@ def clean_job(jobs_to_clean, internal_storage):
     script = """
     from pywren_ibm_cloud.storage import InternalStorage
     from pywren_ibm_cloud.storage.utils import clean_bucket
-    from pywren_ibm_cloud.config import JOBS_PREFIX
+    from pywren_ibm_cloud.config import JOBS_PREFIX, TEMP_PREFIX
     import json
 
     storage_config = {}
+    jobs_to_clean = {}
+    clean_cloudobjects = {}
     bucket = storage_config['bucket']
 
     internal_storage = InternalStorage(storage_config)
 
-    for executor_id, job_id in {}:
+    for executor_id, job_id in jobs_to_clean:
         prefix = '/'.join([JOBS_PREFIX, executor_id, job_id])
         clean_bucket(bucket, prefix, internal_storage, log=False)
-    """.format(storage_config, jobs_to_clean)
+        if clean_cloudobjects:
+            prefix = '/'.join([TEMP_PREFIX, executor_id, job_id])
+            clean_bucket(bucket, prefix, internal_storage, log=False)
+    """.format(storage_config, jobs_to_clean, clean_cloudobjects)
 
     cmdstr = '{} -c "{}"'.format(sys.executable, textwrap.dedent(script))
     os.popen(cmdstr)

--- a/pywren_ibm_cloud/job/job.py
+++ b/pywren_ibm_cloud/job/job.py
@@ -1,5 +1,8 @@
 import os
+import sys
 import time
+import json
+import textwrap
 import pickle
 import logging
 from pywren_ibm_cloud import utils
@@ -202,3 +205,29 @@ def _create_job(config, internal_storage, executor_id, job_id, func, data, runti
     job_description['metadata'] = host_job_meta
 
     return job_description
+
+
+def clean_job(jobs_to_clean, internal_storage):
+    """
+    Clean the jobs in a separate process
+    """
+    storage_config = internal_storage.get_storage_config()
+
+    script = """
+    from pywren_ibm_cloud.storage import InternalStorage
+    from pywren_ibm_cloud.storage.utils import clean_bucket
+    from pywren_ibm_cloud.config import JOBS_PREFIX
+    import json
+
+    storage_config = {}
+    bucket = storage_config['bucket']
+
+    internal_storage = InternalStorage(storage_config)
+
+    for executor_id, job_id in {}:
+        prefix = '/'.join([JOBS_PREFIX, executor_id, job_id])
+        clean_bucket(bucket, prefix, internal_storage, log=False)
+    """.format(storage_config, jobs_to_clean)
+
+    cmdstr = '{} -c "{}"'.format(sys.executable, textwrap.dedent(script))
+    os.popen(cmdstr)

--- a/pywren_ibm_cloud/storage/backends/ibm_cos/ibm_cos.py
+++ b/pywren_ibm_cloud/storage/backends/ibm_cos/ibm_cos.py
@@ -19,7 +19,6 @@ import logging
 import ibm_boto3
 import ibm_botocore
 from datetime import datetime, timezone
-from ibm_boto3.s3.transfer import TransferConfig
 from ibm_botocore.credentials import DefaultTokenManager
 from pywren_ibm_cloud.storage.utils import StorageNoSuchKeyError
 from pywren_ibm_cloud.utils import sizeof_fmt, is_pywren_function

--- a/pywren_ibm_cloud/storage/storage.py
+++ b/pywren_ibm_cloud/storage/storage.py
@@ -1,10 +1,9 @@
 import os
 import json
-import types
 import logging
 import importlib
 from pywren_ibm_cloud.version import __version__
-from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, JOBS_PREFIX
+from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, JOBS_PREFIX, TMP_PREFIX
 from pywren_ibm_cloud.utils import is_pywren_function
 from pywren_ibm_cloud.storage.utils import create_status_key, create_output_key, \
     status_key_suffix, init_key_suffix, CloudObject, StorageNoSuchKeyError
@@ -70,7 +69,6 @@ class InternalStorage:
 
     def get_client(self):
         client = self.storage_handler.get_client()
-        client.cloudobject_count = 0
         client.put_cobject = self.put_cobject
         client.get_cobject = self.get_cobject
 
@@ -85,7 +83,7 @@ class InternalStorage:
         """
         prefix = os.environ.get('PYWREN_EXECUTION_ID', '')
         name = '{}/cloudobject_{}'.format(prefix, self.cloudobject_count)
-        key = key or '/'.join([JOBS_PREFIX, 'cloudobjects', name])
+        key = key or '/'.join([TMP_PREFIX, name])
         bucket = bucket or self.bucket
         self.storage_handler.put_object(bucket, key, body)
         self.cloudobject_count += 1

--- a/pywren_ibm_cloud/storage/storage.py
+++ b/pywren_ibm_cloud/storage/storage.py
@@ -3,7 +3,7 @@ import json
 import logging
 import importlib
 from pywren_ibm_cloud.version import __version__
-from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, JOBS_PREFIX, TMP_PREFIX
+from pywren_ibm_cloud.config import CACHE_DIR, RUNTIMES_PREFIX, JOBS_PREFIX, TEMP_PREFIX
 from pywren_ibm_cloud.utils import is_pywren_function
 from pywren_ibm_cloud.storage.utils import create_status_key, create_output_key, \
     status_key_suffix, init_key_suffix, CloudObject, StorageNoSuchKeyError
@@ -83,7 +83,7 @@ class InternalStorage:
         """
         prefix = os.environ.get('PYWREN_EXECUTION_ID', '')
         name = '{}/cloudobject_{}'.format(prefix, self.cloudobject_count)
-        key = key or '/'.join([TMP_PREFIX, name])
+        key = key or '/'.join([TEMP_PREFIX, name])
         bucket = bucket or self.bucket
         self.storage_handler.put_object(bucket, key, body)
         self.cloudobject_count += 1

--- a/pywren_ibm_cloud/storage/utils.py
+++ b/pywren_ibm_cloud/storage/utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import logging
-import json
 import time
 
 logger = logging.getLogger(__name__)
@@ -53,19 +52,7 @@ class CloudObjectUrl:
         self.path = url_path
 
 
-def clean_bucket(bucket, prefix, storage_config, sleep=5, log=False):
-    """
-    Wrapper of clean_os_bucket(). Use this method only when storage_config is
-    in JSON format. In any other case, call directly clean_os_bucket() method.
-    """
-    from pywren_ibm_cloud.storage import InternalStorage
-    internal_storage = InternalStorage(json.loads(storage_config))
-    # sys.stdout = open(os.devnull, 'w')
-    clean_os_bucket(bucket, prefix, internal_storage, sleep, log)
-    # sys.stdout = sys.__stdout__
-
-
-def clean_os_bucket(bucket, prefix, internal_storage, sleep=5, log=True):
+def clean_bucket(bucket, prefix, internal_storage, sleep=5, log=True):
     """
     Deletes all the files from COS. These files include the function,
     the data serialization and the function invocation results.

--- a/pywren_ibm_cloud/tests.py
+++ b/pywren_ibm_cloud/tests.py
@@ -173,14 +173,14 @@ class TestMethods:
         return final_result
 
     @staticmethod
-    def my_cloudobject_put(obj, internal_storage):
+    def my_cloudobject_put(obj, storage):
         counter = TestMethods.my_map_function_obj(obj, 0)
-        cloudobject = internal_storage.put_object(pickle.dumps(counter))
+        cloudobject = storage.put_cobject(pickle.dumps(counter))
         return cloudobject
 
     @staticmethod
-    def my_cloudobject_get(results, internal_storage):
-        data = [pickle.loads(internal_storage.get_object(cloudobject)) for cloudobject in results]
+    def my_cloudobject_get(results, storage):
+        data = [pickle.loads(storage.get_cobject(cloudobject)) for cloudobject in results]
         return TestMethods.my_reduce_function(data)
 
 
@@ -353,7 +353,8 @@ class TestPywren(unittest.TestCase):
 
     def test_chunks_bucket(self):
         print('Testing chunks on a bucket...')
-        data_prefix = STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
+        sb = STORAGE_CONFIG['backend']
+        data_prefix = sb + '://' + STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
 
         pw = pywren.function_executor(config=CONFIG)
         futures = pw.map_reduce(TestMethods.my_map_function_obj, data_prefix, TestMethods.my_reduce_function,
@@ -370,7 +371,8 @@ class TestPywren(unittest.TestCase):
 
     def test_chunks_bucket_one_reducer_per_object(self):
         print('Testing chunks on a bucket with one reducer per object...')
-        data_prefix = STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
+        sb = STORAGE_CONFIG['backend']
+        data_prefix = sb + '://' + STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
 
         pw = pywren.function_executor(config=CONFIG)
         futures = pw.map_reduce(TestMethods.my_map_function_obj, data_prefix, TestMethods.my_reduce_function,
@@ -388,7 +390,8 @@ class TestPywren(unittest.TestCase):
 
     def test_cloudobject(self):
         print('Testing cloudobjects...')
-        data_prefix = STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
+        sb = STORAGE_CONFIG['backend']
+        data_prefix = sb + '://' + STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
         pw = pywren.function_executor(config=CONFIG)
         pw.map_reduce(TestMethods.my_cloudobject_put, data_prefix, TestMethods.my_cloudobject_get)
         result = pw.get_result()

--- a/pywren_ibm_cloud/tests.py
+++ b/pywren_ibm_cloud/tests.py
@@ -152,10 +152,10 @@ class TestMethods:
         return counter
 
     @staticmethod
-    def my_map_function_ibm_cos(key_i, bucket_name, ibm_cos):
+    def my_map_function_storage(key_i, bucket_name, storage):
         print('I am processing the object /{}/{}'.format(bucket_name, key_i))
         counter = {}
-        data = ibm_cos.get_object(Bucket=bucket_name, Key=key_i)['Body'].read()
+        data = storage.get_object(Bucket=bucket_name, Key=key_i)['Body'].read()
         for line in data.splitlines():
             for word in line.decode('utf-8').split():
                 if word not in counter:
@@ -344,10 +344,10 @@ class TestPywren(unittest.TestCase):
         self.assertEqual(result, self.__class__.cos_result_to_compare)
 
     def test_storage_handler(self):
-        print('Testing ibm_cos function arg...')
+        print('Testing "storage" function arg...')
         iterdata = [[key, STORAGE_CONFIG['bucket']] for key in TestUtils.list_test_keys()]
         pw = pywren.function_executor(config=CONFIG)
-        pw.map_reduce(TestMethods.my_map_function_ibm_cos, iterdata, TestMethods.my_reduce_function)
+        pw.map_reduce(TestMethods.my_map_function_storage, iterdata, TestMethods.my_reduce_function)
         result = pw.get_result()
         self.assertEqual(result, self.__class__.cos_result_to_compare)
 
@@ -392,10 +392,10 @@ class TestPywren(unittest.TestCase):
         print('Testing cloudobjects...')
         sb = STORAGE_CONFIG['backend']
         data_prefix = sb + '://' + STORAGE_CONFIG['bucket'] + '/' + PREFIX + '/'
-        pw = pywren.function_executor(config=CONFIG)
-        pw.map_reduce(TestMethods.my_cloudobject_put, data_prefix, TestMethods.my_cloudobject_get)
-        result = pw.get_result()
-        self.assertEqual(result, self.__class__.cos_result_to_compare)
+        with pywren.ibm_cf_executor(config=CONFIG) as pw:
+            pw.map_reduce(TestMethods.my_cloudobject_put, data_prefix, TestMethods.my_cloudobject_get)
+            result = pw.get_result()
+            self.assertEqual(result, self.__class__.cos_result_to_compare)
 
 
 def print_help():

--- a/pywren_ibm_cloud/utils.py
+++ b/pywren_ibm_cloud/utils.py
@@ -186,12 +186,11 @@ def b64str_to_bytes(str_data):
 
 
 def split_object_url(obj_url):
-    if '://' in obj_url:
-        sb, path = obj_url.split('://')
-    else:
-        sb = 'ibm_cos'
-        path = obj_url
+    if '://' not in obj_url:
+        raise Exception('Object url must contain the storage backend prefix, '
+                        'for example: cos://')
 
+    sb, path = obj_url.split('://')
     sb = 'ibm_cos' if sb == 'cos' else sb
 
     bucket, full_key = path.split('/', 1) if '/' in path else (path, '')
@@ -264,7 +263,7 @@ def verify_args(func, iterdata, extra_params):
     data = format_data(iterdata, extra_params)
 
     # Verify parameters
-    non_verify_args = ['ibm_cos', 'swift', 'internal_storage', 'id', 'rabbitmq']
+    non_verify_args = ['ibm_cos', 'swift', 'storage', 'id', 'rabbitmq']
     func_sig = inspect.signature(func)
 
     new_parameters = list()


### PR DESCRIPTION
Following this thread: #289 

Changed location of the methods used to put/get cloudobjects. Now they are in `ibm_cos` param. `internal_storage` param is no longer supported in functions:

```
internal_storage.put_object() --> ibm_cos.put_cobject()
internal_storage.get_object() --> ibm_cos.get_cobject()
```

`pw.clean()` method is extended to support:
- pw.clean() (without args) internally managed futures and related cloudobjects are deleted.
- pw.clean(fs=futures_list), only the given futures are deleted.
- pw.clean(cs=cloudobjects_list) only the given cloudobjects are deleted.
- pw.clean(fs=futures_list, cs=cloudobjects_list) both are deleted.

Added context manager in PyWren executor. Now it supports:
```python
iterdata = [1, 2, 3, 4]
with pywren.ibm_cf_executor() as pw:
    pw.map(my_map_function, iterdata)
    print(pw.get_result())
```

Managing cloudobjects with context manager. At the end of the with statement all cloudobjects are automatically deleted:
```python
   with pywren.ibm_cf_executor() as pw:
        pw.call_async(my_function_put, 'Hello')
        cloudobjects = pw.get_result()
        pw.map(my_function_get, cloudobjects)
        print(pw.get_result())
```

If using PyWren with the traditional approach, without context manager, internal tmp data is automatically deleted immediately after getting the results. However, `pw.clean()` must be called at the end to delete the cloudobjects created in the same executor as long as you used the default location. Alternatively, you can call `pw.clean(cs=cloudobjects)` to delete a specific list of cloudobjects. `pw.clean(cs=cloudobjects)` is mandatory if you created the cloudobjects in a custom location.

```python
    pw = pywren.ibm_cf_executor()
    pw.call_async(my_function_put, 'Hello')
    cloudobjects = pw.get_result()
    pw.map(my_function_get, cloudobjects)
    result = pw.get_result()
    pw.clean()  # or pw.clean(cs=cloudobjects)
    print(result)
```

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

