### PR TITLE
Added option to run custom code before jobrunner run

### DIFF
--- a/pywren_ibm_cloud/function/jobrunner.py
+++ b/pywren_ibm_cloud/function/jobrunner.py
@@ -34,6 +34,8 @@ from pywren_ibm_cloud.utils import sizeof_fmt, b64str_to_bytes, is_object_proces
 from pywren_ibm_cloud.utils import WrappedStreamingBodyPartition
 from pywren_ibm_cloud.config import extract_storage_config, cloud_logging_config
 
+from pydoc import locate
+
 pickling_support.install()
 logger = logging.getLogger('JobRunner')
 
@@ -230,6 +232,21 @@ class JobRunner:
                                                 extra_get_args=extra_get_args)
                 obj.data_stream = sb
 
+    # Decorator to execute pre-run and post-run functions provided via environment variables
+    def prepost(func):
+        def call(envVar):
+            if envVar in os.environ:
+                method = locate(os.environ[envVar])
+                method()
+
+        def wrapper_decorator(*args, **kwargs):
+            call('PRE_RUN')
+            value = func(*args, **kwargs)
+            call('POST_RUN')
+            return value
+        return wrapper_decorator
+
+    @prepost
     def run(self):
         """
         Runs the function


### PR DESCRIPTION
This feature is to allow custom code execution before user function and after user function, thus, cleanly separating between initialization and finalization specific to the execution environment (e.g., database connection initialization/finalization).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

