### PR TITLE
Fix case where function argument is a list or tuple.

### DIFF
--- a/pywren_ibm_cloud/tests.py
+++ b/pywren_ibm_cloud/tests.py
@@ -75,6 +75,10 @@ class TestMethods:
         return "Hello World!"
 
     @staticmethod
+    def concat(lst):
+        return " ".join(lst)
+
+    @staticmethod
     def simple_map_function(x, y):
         return x + y
 
@@ -203,6 +207,11 @@ class TestPywren(unittest.TestCase):
         self.assertEqual(result, "Hello World!")
 
         pw = pywren.function_executor(config=CONFIG)
+        pw.call_async(TestMethods.concat, ["a", "b"])
+        result = pw.get_result()
+        self.assertEqual(result, "a b")
+
+        pw = pywren.function_executor(config=CONFIG)
         pw.call_async(TestMethods.simple_map_function, [4, 6])
         result = pw.get_result()
         self.assertEqual(result, 10)
@@ -242,6 +251,12 @@ class TestPywren(unittest.TestCase):
         pw.map(TestMethods.simple_map_function, listDicts_iterdata)
         result = pw.get_result()
         self.assertEqual(result, [10, 10])
+
+        pw = pywren.function_executor(config=CONFIG)
+        set_iterdata = [["a", "b"], ["c", "d"]]
+        pw.map(TestMethods.concat, set_iterdata)
+        result = pw.get_result()
+        self.assertEqual(result, ["a b", "c d"])
 
     def test_map_reduce(self):
         print('Testing map_reduce()...')

--- a/pywren_ibm_cloud/utils.py
+++ b/pywren_ibm_cloud/utils.py
@@ -283,7 +283,7 @@ def verify_args(func, iterdata, extra_args):
                                  "You provided these args: {}, and "
                                  "the args must be: {}".format(list(elem.keys()),
                                                                list(new_func_sig.parameters.keys())))
-        elif type(elem) in (list, tuple):
+        elif type(elem) in (list, tuple) and len(elem) == len(new_func_sig.parameters):
             new_elem = dict(new_func_sig.bind(*list(elem)).arguments)
             new_data.append(new_elem)
         else:


### PR DESCRIPTION
If the argument to a Pywren function is a list or a tuple then it is not handled correctly in `verify_args`. This PR provides a fix and a test that fails without the fix.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

