### PR TITLE
Fix localhost subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [PyWren] Fixed invoker token bucket when quota limit is reached
 - [PyWren] Fixed logging
 - [PyWren] Foxed invoker when it reaches quota limit
+- [Localhost] Fixed invocations ability to launch subprocesses
 
 ### Changed
 - [PyWren] Improved Storage abstraction

--- a/pywren_ibm_cloud/compute/backends/localhost/localhost.py
+++ b/pywren_ibm_cloud/compute/backends/localhost/localhost.py
@@ -40,7 +40,6 @@ class LocalhostBackend:
             for worker_id in range(self.num_workers):
                 p = Process(target=self._process_runner, args=(worker_id,))
                 self.workers.append(p)
-                p.daemon = True
                 p.start()
 
         log_msg = 'PyWren v{} init for Localhost - Total workers: {}'.format(__version__, self.num_workers)


### PR DESCRIPTION
Fixes https://github.com/metaspace2020/pywren-annotation-pipeline/issues/80

`Process.daemon` prevents subprocesses from creating new child processes. LocalhostBackend's worker processes are used to invoke user code, and user code may want to create child processes for performance reasons, or to launch external tools. Therefore, it's undesirable to spawn these worker processes with the `daemon` flag.

There is a side effect: Daemon processes are supposedly automatically killed during Python shutdown when the parent process exits, and removing the daemon flag removes this nice automatic cleanup behavior. To fix this, I added extra code to clean up any remaining worker processes when Python shuts down.
 
This change is not needed for the codepath that uses `Threads`s, because `Thread.daemon` has different behavior and doesn't prevent creating processes.



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

