### PR TITLE
Added auto_dismantle call from runtime container

### DIFF
--- a/docs/ibm_vpc.md
+++ b/docs/ibm_vpc.md
@@ -29,6 +29,7 @@ The IBM VPC client is a component for PyWren's docker executor using a remote ho
        compute_backend: docker
        storage_backend: ibm_cos
        auto_dismantle: True
+       remote_client: ibm_vpc
    
    ibm:
        iam_api_key: <iam-api-key>
@@ -38,18 +39,21 @@ The IBM VPC client is a component for PyWren's docker executor using a remote ho
        ssh_user: root
        ssh_password: <passphrase> # OPTIONAL, will use '' if not provided
        ssh_key_filename: <private-ssh-key-path> # OPTIONAL, will use the default path if not provided
-       remote_client: ibm_vpc
    
    ibm_vpc:
        endpoint: <endpoint>
        instance_id: <instance-id>
        version: dd-mm-yyyy # OPTIONAL, will use today's date if not provided
        generation: 1/2 # OPTIONAL, will use 2 if not provided
+       dismantle_timeout: 300 # if auto_dismantle=True, after this timeout (seconds), the VPC instance sygnaled to stop from inside runtime
+       start_timeout: 300
    ```
 
    - **version**: use for specifying IBM VPC production application version date, it is recommended to configure it statically
    - **generation**: use for specifying IBM VPC environment compute generation, see [Comparing compute generations in VPC](https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-vpc-vpcoc) for additional information
-   - **pywren.auto_dismantle**:  if False then VM not stopped automatically after execution. run **exec.dismantle()** expicitly to stop VM.
+   - **pywren.auto_dismantle**:  if False then VM not stopped automatically after execution. run **exec.dismantle()** expicitly to stop VM
+   - **dismantle_timeout**: in some cases, e.g. loss of network communication with VPC, the auto_dismantle may fail. in such case, after specified **dismantle_timeout** timeout dismantle procedure will be initiated from inside runtime container
+   - **start_timeout**: time in seconds to wait untill the VPC instance start
 
 ### Verify
 

--- a/docs/ibm_vpc.md
+++ b/docs/ibm_vpc.md
@@ -52,8 +52,8 @@ The IBM VPC client is a component for PyWren's docker executor using a remote ho
    - **version**: use for specifying IBM VPC production application version date, it is recommended to configure it statically
    - **generation**: use for specifying IBM VPC environment compute generation, see [Comparing compute generations in VPC](https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-vpc-vpcoc) for additional information
    - **pywren.auto_dismantle**:  if False then VM not stopped automatically after execution. run **exec.dismantle()** expicitly to stop VM
-   - **soft_dismantle_timeout**: in some cases, e.g. loss of network communication with VPC, the auto_dismantle may fail. in such case, after specified **soft_dismantle_timeout** timeout since last **completed** invocation, the dismantle procedure will be initiated from inside runtime container. 5 minutes by default. Set to -1 to disable
-   - **hard_dismantle_timeout**: after specified **hard_dismantle_timeout** timeout since last invocation **started**, the dismantle procedure will be initiated from inside runtime container. 3 hours by default. Set to -1 to disable
+   - **soft_dismantle_timeout**: in some cases, e.g. loss of network communication with VPC, the auto_dismantle may fail. in such case, after specified **soft_dismantle_timeout** timeout since last **completed** invocation, the dismantle procedure will be initiated from inside runtime container. 5 minutes by default.
+   - **hard_dismantle_timeout**: after specified **hard_dismantle_timeout** timeout since last invocation **started**, the dismantle procedure will be initiated from inside runtime container. 3 hours by default.
    - **start_timeout**: time in seconds to wait untill the VPC instance start
 
 ### Verify

--- a/docs/ibm_vpc.md
+++ b/docs/ibm_vpc.md
@@ -45,14 +45,15 @@ The IBM VPC client is a component for PyWren's docker executor using a remote ho
        instance_id: <instance-id>
        version: dd-mm-yyyy # OPTIONAL, will use today's date if not provided
        generation: 1/2 # OPTIONAL, will use 2 if not provided
-       dismantle_timeout: 300 # if auto_dismantle=True, after this timeout (seconds), the VPC instance sygnaled to stop from inside runtime
-       start_timeout: 300
+       soft_dismantle_timeout: 300 # timeout (seconds) since last completed invocation after which the VPC instance signaled to stop from inside runtime
+       hard_dismantle_timeout: 10800 # timeout since last started invocation after which the VPC instance signaled to stop from inside runtime
    ```
 
    - **version**: use for specifying IBM VPC production application version date, it is recommended to configure it statically
    - **generation**: use for specifying IBM VPC environment compute generation, see [Comparing compute generations in VPC](https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-vpc-vpcoc) for additional information
    - **pywren.auto_dismantle**:  if False then VM not stopped automatically after execution. run **exec.dismantle()** expicitly to stop VM
-   - **dismantle_timeout**: in some cases, e.g. loss of network communication with VPC, the auto_dismantle may fail. in such case, after specified **dismantle_timeout** timeout dismantle procedure will be initiated from inside runtime container
+   - **soft_dismantle_timeout**: in some cases, e.g. loss of network communication with VPC, the auto_dismantle may fail. in such case, after specified **soft_dismantle_timeout** timeout since last **completed** invocation, the dismantle procedure will be initiated from inside runtime container. 5 minutes by default. Set to -1 to disable
+   - **hard_dismantle_timeout**: after specified **hard_dismantle_timeout** timeout since last invocation **started**, the dismantle procedure will be initiated from inside runtime container. 3 hours by default. Set to -1 to disable
    - **start_timeout**: time in seconds to wait untill the VPC instance start
 
 ### Verify

--- a/pywren_ibm_cloud/compute/backends/docker/config.py
+++ b/pywren_ibm_cloud/compute/backends/docker/config.py
@@ -53,13 +53,3 @@ def load_config(config_data):
 
     if 'ibm_cos' in config_data and 'private_endpoint' in config_data['ibm_cos']:
         del config_data['ibm_cos']['private_endpoint']
-
-    if 'remote_client' in config_data['docker']:
-        remote_client_backend = config_data['docker']['remote_client']
-
-        remote_client_config = importlib.import_module('pywren_ibm_cloud.libs.clients.{}.config'
-                                                       .format(remote_client_backend))
-        remote_client_config.load_config(config_data)
-
-        remote_client_config = config_data.pop(remote_client_backend)
-        config_data['docker'][remote_client_backend] = remote_client_config

--- a/pywren_ibm_cloud/compute/compute.py
+++ b/pywren_ibm_cloud/compute/compute.py
@@ -16,6 +16,7 @@
 
 import logging
 import importlib
+from pywren_ibm_cloud.compute.utils import get_remote_client
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +37,10 @@ class Compute:
             cb_module = importlib.import_module(module_location)
             ComputeBackend = getattr(cb_module, 'ComputeBackend')
             self.compute_handler = ComputeBackend(self.config[self.backend])
-            self.remote_client = self._get_remote_client(self.config[self.backend])
+            self.remote_client = get_remote_client(self.config)
 
             # if backend supports, check if ready. run client to setup in case not ready
-            if hasattr(self.compute_handler, 'ready') and not self.compute_handler.ready():
-                self._setup_compute()
-                self.remote_client.create_instance_action('start')
+            self._setup_compute()
 
         except Exception as e:
             logger.error("There was en error trying to create the '{}' compute backend".format(e))
@@ -49,20 +48,12 @@ class Compute:
 
     def _setup_compute(self):
         logger.info("Starting setup of compute backend")
-        self.remote_client.create_instance_action('start')
-        logger.info("Waiting for compute to become ready")
-        if not self.compute_handler.ready(retries=10, timeout=20):
-            raise Exception("The remote compute is not ready")
+        readiness_probe = None
+        if hasattr(self.compute_handler, 'ready'):
+            readiness_probe = self.compute_handler.ready
 
-    def _get_remote_client(self, backend_config):
-        if 'remote_client' in backend_config:
-            remote_client_backend = backend_config['remote_client']
-            client_location = 'pywren_ibm_cloud.libs.clients.{}'.format(remote_client_backend)
-            client = importlib.import_module(client_location)
-            RemoteInstanceClient = getattr(client, 'RemoteInstanceClient')
-            return RemoteInstanceClient(backend_config[remote_client_backend],
-                                                       user_agent=backend_config['user_agent'])
-        return None
+        if self.remote_client:
+            self.remote_client.setup(readiness_probe=readiness_probe)
 
     def invoke(self, runtime_name, memory, payload):
         """
@@ -113,7 +104,7 @@ class Compute:
     def dismantle(self):
         if self.remote_client:
             logger.info("Dismantling setup")
-            self.remote_client.create_instance_action('stop')
+            self.remote_client.dismantle()
 
     def __del__(self):
         if self.compute_handler and hasattr(self.compute_handler, '__del__'):

--- a/pywren_ibm_cloud/compute/utils.py
+++ b/pywren_ibm_cloud/compute/utils.py
@@ -18,6 +18,7 @@ import os
 import zipfile
 import logging
 import pywren_ibm_cloud
+import importlib
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +45,15 @@ def create_function_handler_zip(zip_location, main_exec_file, backend_location):
 
     except Exception:
         raise Exception('Unable to create the {} package: {}'.format(zip_location))
+
+def get_remote_client(config):
+    if 'remote_client' in config:
+        remote_client_backend = config['remote_client']
+        remote_client_config = config[remote_client_backend]
+
+        client_location = 'pywren_ibm_cloud.libs.clients.{}'.format(remote_client_backend)
+        client = importlib.import_module(client_location)
+        RemoteInstanceClient = getattr(client, 'RemoteInstanceClient')
+        return RemoteInstanceClient(remote_client_config,
+                                    user_agent=remote_client_config['user_agent'])
+    return None

--- a/pywren_ibm_cloud/config.py
+++ b/pywren_ibm_cloud/config.py
@@ -166,6 +166,15 @@ def extract_compute_config(config):
     compute_config[cb]['user_agent'] = 'pywren-ibm-cloud/{}'.format(__version__)
     if 'compute_backend_region' in config['pywren']:
         compute_config[cb]['region'] = config['pywren']['compute_backend_region']
+    if 'remote_client' in config['pywren']:
+        remote_client_backend = config['pywren']['remote_client']
+        remote_client_config = importlib.import_module('pywren_ibm_cloud.libs.clients.{}.config'
+                                                       .format(remote_client_backend))
+        remote_client_config.load_config(config)
+
+        remote_client_config = config[remote_client_backend]
+        compute_config[remote_client_backend] = remote_client_config
+        compute_config['remote_client'] = config['pywren']['remote_client']
 
     return compute_config
 

--- a/pywren_ibm_cloud/executor.py
+++ b/pywren_ibm_cloud/executor.py
@@ -502,10 +502,5 @@ class FunctionExecutor:
         if self.auto_dismantle:
             self.dismantle()
 
-    def __del__(self):
-        if self.auto_dismantle:
-            print("Auto dismantle enabled")
-            self.dismantle()
-
     def dismantle(self):
         self.invoker.dismantle()

--- a/pywren_ibm_cloud/libs/clients/ibm_vpc/config.py
+++ b/pywren_ibm_cloud/libs/clients/ibm_vpc/config.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+import datetime
+
+from pywren_ibm_cloud.version import __version__
 
 
 def load_config(config_data):
@@ -18,6 +20,10 @@ def load_config(config_data):
         raise Exception(msg)
 
     if 'version' not in config_data:
-        config_data[section]['version'] = datetime.today().strftime('%Y-%m-%d')
+        # it is not safe to use version as today() due to timezone differences. may fail at midnight. better use yesterday
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+        config_data[section]['version'] = yesterday.strftime('%Y-%m-%d')
     if 'generation' not in config_data:
         config_data[section]['generation'] = 2
+
+    config_data[section]['user_agent'] = 'pywren-ibm-cloud/{}'.format(__version__)

--- a/pywren_ibm_cloud/libs/clients/ibm_vpc/ibm_vpc.py
+++ b/pywren_ibm_cloud/libs/clients/ibm_vpc/ibm_vpc.py
@@ -30,7 +30,8 @@ class IBMVPCInstanceClient:
         adapter = requests.adapters.HTTPAdapter()
         self.session.mount('https://', adapter)
 
-        self.dismantle_timeout = self.config.get('dismantle_timeout', 300) # if not specified, 5 minutes to dismantle after last used
+        self.soft_dismantle_timeout = self.config.get('soft_dismantle_timeout', 300) # if not specified, 5 minutes to dismantle after last completed
+        self.hard_dismantle_timeout = self.config.get('hard_dismantle_timeout', 10800) # if not specified, 3 hours to dismantle after last invoked
 
     def _authorize_session(self):
         self.config['token'], self.config['token_expiry_time'] = self.ibm_iam_api_key_manager.get_token()

--- a/pywren_ibm_cloud/libs/clients/ibm_vpc/ibm_vpc.py
+++ b/pywren_ibm_cloud/libs/clients/ibm_vpc/ibm_vpc.py
@@ -30,6 +30,8 @@ class IBMVPCInstanceClient:
         adapter = requests.adapters.HTTPAdapter()
         self.session.mount('https://', adapter)
 
+        self.dismantle_timeout = self.config.get('dismantle_timeout', 300) # if not specified, 5 minutes to dismantle after last used
+
     def _authorize_session(self):
         self.config['token'], self.config['token_expiry_time'] = self.ibm_iam_api_key_manager.get_token()
         self.session.headers['Authorization'] = 'Bearer ' + self.config['token']
@@ -57,10 +59,23 @@ class IBMVPCInstanceClient:
         resp_text = res.json()
 
         if res.status_code != 201:
-            msg = 'An error occurred creating instance action {}: {}'.format(type, resp_text['error'])
+            msg = 'An error occurred creating instance action {}: {}'.format(type, resp_text['errors'])
             raise Exception(msg)
 
         while self.get_instance()['status'] != expected_status:
             time.sleep(1)
 
         logger.debug("Created instance action {} successfully".format(type))
+
+    def setup(self, readiness_probe=None):
+        if readiness_probe():
+            return
+        else:
+            self.create_instance_action('start')
+            start_timeout = self.config.get('start_timeout', 300)
+            logger.info("Waiting for compute backend to become ready")
+            if not readiness_probe(timeout=start_timeout):
+                raise Exception("Failed to make the compute ready")
+
+    def dismantle(self):
+        self.create_instance_action('stop')


### PR DESCRIPTION
In current implementation, dismantle procedure invoked from host may not be triggered.
For example, in case of network connectivity loss or exception.

- added keeper thread in pywren_ibm_cloud/compute/backends/docker/entry_point.py
- code refactoring to remove remote_agent out of the docker backend layer completely
- refactored code to avoid duplication



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

